### PR TITLE
Release 0.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,24 @@
 # rc-tracks history
 
+## [Version 0.4.0](https://github.com/jsconan/rc-tracks/releases/tag/0.4.0)
+
+Improved design of the race track system for 1/24 to 1/32 scale RC cars.
+
+-   Encapsulate the shapes into final modules
+-   Add sizing functions
+-   Add more printer constraints (size of the printer's plate)
+-   Add print plates for sets of elements
+-   The file structure has been updated.
+-   Add a special barrier connector to link barrier holders to unibody barriers (straight version only)
+-   The render script has been reworked, adding more options
+
+---
+
+Notes:
+
+-   Import from the repository [jsconan/things](https://github.com/jsconan/things)
+-   Extract of the pull request https://github.com/jsconan/things/pull/47
+
 ## [Version 0.3.0](https://github.com/jsconan/rc-tracks/releases/tag/0.3.0)
 
 Improved design of the race track system for 1/24 to 1/32 scale RC cars.

--- a/rcmodels/tracks/config/config.scad
+++ b/rcmodels/tracks/config/config.scad
@@ -28,15 +28,17 @@
  * @author jsconan
  */
 
- projectVersion = "0.3.0";
+ projectVersion = "0.4.0";
 
 // We will render the object using the specifications of this mode
 renderMode = MODE_PROD;
 
 // Defines the constraints of the printer.
 printResolution = 0.2;  // The target layer height
-nozzleWidth = 0.4;      // The size of the print nozzle
+nozzleWidth = 0.4;      // The size of the printer's nozzle
 printTolerance = 0.1;   // The print tolerance when pieces need to be assembled
+printerLength = 250;    // The length of the printer's build plate
+printerWidth = 210;     // The width of the printer's build plate
 
 // The dimensions and constraints of a track element
 trackSectionLength = 100;       // The nominal length of a track element: the length for straight element, or the radius for a curved element
@@ -53,7 +55,9 @@ accessoryClipThickness = 0.8;   // The thickness of the cable clip
 cableClipWidth = 2;             // The width of the cable clip
 mastWidth = 3;                  // The width of the accessory mast
 mastHeight = 70;                // The length of the accessory mast
+mastFacets = 8;                 // The number of facets the accessory mast have
 flagWidth = 40;                 // The width of the accessory flag
 flagHeight = 20;                // The height of the accessory flag
 flagThickness = 0.8;            // The thickness of the accessory flag
 rightOriented = false;          // The orientation of the curved elements
+printInterval = 5;              // Interval between 2 pieces when presented together

--- a/rcmodels/tracks/config/values.scad
+++ b/rcmodels/tracks/config/values.scad
@@ -105,9 +105,10 @@ function getBarrierNotchDistance(base, distance = 0) = (getBarrierLinkWidth(base
 /**
  * Computes the outer width of a barrier holder.
  * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number [distance] - An additional distance added to the outline of the barrier holder.
  * @returns Number
  */
-function getBarrierHolderWidth(base) = getBarrierLinkWidth(base, printTolerance) + minWidth * 4;
+function getBarrierHolderWidth(base, distance = 0) = getBarrierLinkWidth(base, printTolerance) + minWidth * 4 + distance * 2;
 
 /**
  * Computes the top width of a barrier holder.
@@ -120,9 +121,10 @@ function getBarrierHolderTopWidth(base, thickness) = nozzleAligned((getBarrierLi
 /**
  * Computes the outer height of a barrier holder.
  * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number [distance] - An additional distance added to the outline of the barrier holder.
  * @returns Number
  */
-function getBarrierHolderHeight(base) = getBarrierStripHeight(base) + minThickness + printResolution;
+function getBarrierHolderHeight(base, distance = 0) = getBarrierStripHeight(base) + minThickness + printResolution + distance * 2;
 
 /**
  * Computes the height of the link for a barrier holder.
@@ -134,9 +136,10 @@ function getBarrierHolderLinkHeight(base) = getBarrierHolderHeight(base) - base;
 /**
  * Computes the outer width of a unibody barrier.
  * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number [distance] - An additional distance added to the outline of the barrier.
  * @returns Number
  */
-function getBarrierUnibodyWidth(base) = getBarrierHolderWidth(base) + base;
+function getBarrierUnibodyWidth(base, distance = 0) = getBarrierHolderWidth(base) + base + distance * 2;
 
 /**
  * Computes the height of the link for a unibody barrier.
@@ -222,11 +225,35 @@ function getCurveRadius(length, ratio) = length * ratio;
 function getCurveAngle(ratio) = curveAngle / ratio;
 
 /**
+ * Computes the rotation angle used to place a curve.
+ * @param Number angle - The angle of the curve.
+ * @returns Number
+ */
+function getCurveRotationAngle(angle) = 45 + (curveAngle - angle) / 2;
+
+/**
  * Computes the radius of the accessory mast.
  * @param Number width - The width of the mast.
  * @returns Number
  */
 function getMastRadius(width) = circumradius(n = mastFacets, a = width / 2);
+
+/**
+ * Computes the print interval between the centers of 2 objects.
+ * @param Number size - The size of the shape.
+ * @returns Number
+ */
+function getPrintInterval(size) = size + printInterval;
+
+/**
+ * Centers the children elements to te printer's build plate.
+ */
+module centerBuildPlate(moveOrigin = false) {
+    buildPlate([printerLength, printerWidth], center=!moveOrigin);
+    translate(moveOrigin ? [printerLength, printerWidth, 0] / 2 : [0, 0, 0]) {
+        children();
+    }
+};
 
 /**
  * Validates the config values, checking if it match the critical constraints.
@@ -329,6 +356,9 @@ module printConfig(length, width, lane, height, radius, base) {
         str("Nozzle diameter:       ", nozzleWidth, "mm"),
         str("Print layer:           ", printResolution, "mm"),
         str("Print tolerance:       ", printTolerance, "mm"),
+        str("Printer's length:      ", printerLength / 10, "cm"),
+        str("Printer's width:       ", printerWidth / 10, "cm"),
+        str("Print interval:        ", printInterval, "mm"),
         ""
     ], str(chr(13), chr(10))));
 }
@@ -345,6 +375,3 @@ stripIndentRatio = 0.5;
 
 // The angle of a typical curve
 curveAngle = 90;
-
-// The number of facets the accessory mast have
-mastFacets = 6;

--- a/rcmodels/tracks/parts/accessories/bent-mast.scad
+++ b/rcmodels/tracks/parts/accessories/bent-mast.scad
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A bent mast to clip accessories onto the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+
+/**
+ * Gets the length of the final shape for a bent mast.
+ * @returns Number
+ */
+function finalBentMastLength() =
+    getAccessoryBentMastLength(
+        width = mastWidth,
+        height = [mastWidth, mastHeight],
+        wall = accessoryClipThickness,
+        base = barrierHolderBase
+    )
+;
+
+/**
+ * Gets the width of the final shape for a bent mast.
+ * @returns Number
+ */
+function finalBentMastWidth() =
+    getAccessoryBentMastWidth(
+        width = mastWidth,
+        height = [mastWidth, mastHeight],
+        wall = accessoryClipThickness,
+        base = barrierHolderBase
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a bent mast.
+ * @returns Number
+ */
+function finalBentMastIntervalX() =
+    getPrintInterval(
+        finalBentMastLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a bent mast.
+ * @returns Number
+ */
+function finalBentMastIntervalY() =
+    getPrintInterval(
+        finalBentMastWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a bent mast.
+ */
+module finalBentMast() {
+    accessoryBentMast(
+        width = mastWidth,
+        height = [mastWidth, mastHeight],
+        wall = accessoryClipThickness,
+        base = barrierHolderBase,
+        thickness = barrierBodyThickness
+    );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalBentMast();
+}

--- a/rcmodels/tracks/parts/accessories/cable-clip.scad
+++ b/rcmodels/tracks/parts/accessories/cable-clip.scad
@@ -31,14 +31,63 @@
 // Import the project's setup.
 include <../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the length of the final shape for a cable clip.
+ * @returns Number
+ */
+function finalCableClipLength() =
+    getCableClipLength(
+        wall = accessoryClipThickness,
+        base = barrierHolderBase
+    )
+;
+
+/**
+ * Gets the width of the final shape for a cable clip.
+ * @returns Number
+ */
+function finalCableClipWidth() =
+    getCableClipWidth(
+        wall = accessoryClipThickness,
+        base = barrierHolderBase
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a cable clip.
+ * @returns Number
+ */
+function finalCableClipIntervalX() =
+    getPrintInterval(
+        finalCableClipLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a cable clip.
+ * @returns Number
+ */
+function finalCableClipIntervalY() =
+    getPrintInterval(
+        finalCableClipWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a cable clip.
+ */
+module finalCableClip() {
     cableClip(
         height = cableClipWidth,
         wall = accessoryClipThickness,
         base = barrierHolderBase,
         thickness = barrierBodyThickness
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalCableClip();
 }

--- a/rcmodels/tracks/parts/accessories/straight-flag.scad
+++ b/rcmodels/tracks/parts/accessories/straight-flag.scad
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A straight flag to clip onto the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+
+/**
+ * Gets the length of the final shape for a straight flag.
+ * @returns Number
+ */
+function finalStraightFlagLength() =
+    getAccessoryFlagLength(
+        width = flagWidth,
+        thickness = flagThickness,
+        mast = mastWidth
+    )
+;
+
+/**
+ * Gets the width of the final shape for a straight flag.
+ * @returns Number
+ */
+function finalStraightFlagWidth() =
+    getAccessoryFlagWidth(
+        height = flagHeight,
+        wave = 0
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a straight flag.
+ * @returns Number
+ */
+function finalStraightFlagIntervalX() =
+    getPrintInterval(
+        finalStraightFlagLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a straight flag.
+ * @returns Number
+ */
+function finalStraightFlagIntervalY() =
+    getPrintInterval(
+        finalStraightFlagWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a straight flag.
+ */
+module finalStraightFlag() {
+    accessoryFlag(
+        width = flagWidth,
+        height = flagHeight,
+        thickness = flagThickness,
+        mast = mastWidth,
+        wave = 0
+    );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalStraightFlag();
+}

--- a/rcmodels/tracks/parts/accessories/straight-mast.scad
+++ b/rcmodels/tracks/parts/accessories/straight-mast.scad
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A mast to clip accessories onto the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+
+/**
+ * Gets the length of the final shape for a straight mast.
+ * @returns Number
+ */
+function finalStraightMastLength() =
+    getAccessoryStraightMastLength(
+        height = mastHeight,
+        wall = accessoryClipThickness,
+        base = barrierHolderBase
+    )
+;
+
+/**
+ * Gets the width of the final shape for a straight mast.
+ * @returns Number
+ */
+function finalStraightMastWidth() =
+    getAccessoryStraightMastWidth(
+        wall = accessoryClipThickness,
+        base = barrierHolderBase
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a straight mast.
+ * @returns Number
+ */
+function finalStraightMastIntervalX() =
+    getPrintInterval(
+        finalStraightMastLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a straight mast.
+ * @returns Number
+ */
+function finalStraightMastIntervalY() =
+    getPrintInterval(
+        finalStraightMastWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a straight mast.
+ */
+module finalStraightMast() {
+    accessoryStraightMast(
+        width = mastWidth,
+        height = mastHeight,
+        wall = accessoryClipThickness,
+        base = barrierHolderBase,
+        thickness = barrierBodyThickness
+    );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalStraightMast();
+}

--- a/rcmodels/tracks/parts/accessories/wavy-flag.scad
+++ b/rcmodels/tracks/parts/accessories/wavy-flag.scad
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A wavy flag to clip onto the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+
+/**
+ * Gets the length of the final shape for a wavy flag.
+ * @returns Number
+ */
+function finalWavyFlagLength() =
+    getAccessoryFlagLength(
+        width = flagWidth,
+        thickness = flagThickness,
+        mast = mastWidth
+    )
+;
+
+/**
+ * Gets the width of the final shape for a wavy flag.
+ * @returns Number
+ */
+function finalWavyFlagWidth() =
+    getAccessoryFlagWidth(
+        height = flagHeight,
+        wave = 2
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a wavy flag.
+ * @returns Number
+ */
+function finalWavyFlagIntervalX() =
+    getPrintInterval(
+        finalWavyFlagLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a wavy flag.
+ * @returns Number
+ */
+function finalWavyFlagIntervalY() =
+    getPrintInterval(
+        finalWavyFlagWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a wavy flag.
+ */
+module finalWavyFlag() {
+    accessoryFlag(
+        width = flagWidth,
+        height = flagHeight,
+        thickness = flagThickness,
+        mast = mastWidth,
+        wave = 2
+    );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalWavyFlag();
+}

--- a/rcmodels/tracks/parts/elements/curved/curved-inner.scad
+++ b/rcmodels/tracks/parts/elements/curved/curved-inner.scad
@@ -31,15 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierHolderRatio() = getInnerCurveRatio(trackSectionLength, trackRadius);
+
+/**
+ * Gets the length of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierHolderLength() =
+    getCurvedBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalInnerCurvedBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierHolderWidth() =
+    getCurvedBarrierWidth(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalInnerCurvedBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierHolderIntervalX() =
+    getPrintInterval(
+        finalInnerCurvedBarrierHolderLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierHolderIntervalY() =
+    getPrintInterval(
+        getBarrierHolderWidth(barrierHolderBase)
+    )
+;
+
+/**
+ * Defines the final shape for an inner curve.
+ */
+module finalInnerCurvedBarrierHolder() {
     curvedBarrierHolder(
         length = trackSectionLength,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = getInnerCurveRatio(trackSectionLength, trackRadius),
+        ratio = finalInnerCurvedBarrierHolderRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalInnerCurvedBarrierHolder();
 }

--- a/rcmodels/tracks/parts/elements/curved/curved-outer.scad
+++ b/rcmodels/tracks/parts/elements/curved/curved-outer.scad
@@ -31,15 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierHolderRatio() = getOuterCurveRatio(trackSectionLength, trackSectionWidth, trackRadius);
+
+/**
+ * Gets the length of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierHolderLength() =
+    getCurvedBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalOuterCurvedBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierHolderWidth() =
+    getCurvedBarrierWidth(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalOuterCurvedBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierHolderIntervalX() =
+    getPrintInterval(
+        finalOuterCurvedBarrierHolderLength()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierHolderIntervalY() =
+    getPrintInterval(
+        getBarrierHolderWidth(barrierHolderBase)
+    )
+;
+
+/**
+ * Defines the final shape for an outer curve.
+ */
+module finalOuterCurvedBarrierHolder() {
     curvedBarrierHolder(
         length = trackSectionLength,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = getOuterCurveRatio(trackSectionLength, trackSectionWidth, trackRadius),
+        ratio = finalOuterCurvedBarrierHolderRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalOuterCurvedBarrierHolder();
 }

--- a/rcmodels/tracks/parts/elements/curved/curved-short.scad
+++ b/rcmodels/tracks/parts/elements/curved/curved-short.scad
@@ -31,15 +31,75 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierHolderRatio() = .5;
+
+/**
+ * Gets the length of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierHolderLength() =
+    getCurvedBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalShortCurvedBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierHolderWidth() =
+    getCurvedBarrierWidth(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalShortCurvedBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierHolderIntervalX() =
+    getPrintInterval(
+        finalShortCurvedBarrierHolderLength() / 4
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierHolderIntervalY() =
+    getPrintInterval(
+        getBarrierHolderWidth(barrierHolderBase) +
+        getBarrierLinkLength(barrierHolderBase)
+    )
+;
+
+/**
+ * Defines the final shape for a short curve.
+ */
+module finalShortCurvedBarrierHolder() {
     curvedBarrierHolder(
         length = trackSectionLength,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = .5,
+        ratio = finalShortCurvedBarrierHolderRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalShortCurvedBarrierHolder();
 }

--- a/rcmodels/tracks/parts/elements/curved/curved-small.scad
+++ b/rcmodels/tracks/parts/elements/curved/curved-small.scad
@@ -31,15 +31,76 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierHolderRatio() = 1;
+
+/**
+ * Gets the length of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierHolderLength() =
+    getCurvedBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalSmallCurvedBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierHolderWidth() =
+    getCurvedBarrierWidth(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalSmallCurvedBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierHolderIntervalX() =
+    getPrintInterval(
+        finalSmallCurvedBarrierHolderLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierHolderIntervalY() =
+    getPrintInterval(
+        getBarrierHolderWidth(barrierHolderBase) +
+        getBarrierLinkLength(barrierHolderBase)
+    )
+;
+
+/**
+ * Defines the final shape for a small curve.
+ */
+module finalSmallCurvedBarrierHolder() {
     curvedBarrierHolder(
         length = trackSectionLength,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = 1,
+        ratio = finalSmallCurvedBarrierHolderRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalSmallCurvedBarrierHolder();
 }

--- a/rcmodels/tracks/parts/elements/curved/curved-uturn.scad
+++ b/rcmodels/tracks/parts/elements/curved/curved-uturn.scad
@@ -31,16 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the size of the gap between the 2 sides of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierHolderGap() = archTowerThickness * 2;
+
+/**
+ * Gets the length of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierHolderLength() =
+    getUTurnBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        gap = finalUTurnCurvedBarrierHolderGap()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierHolderWidth() =
+    getUTurnBarrierWidth(
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        gap = finalUTurnCurvedBarrierHolderGap()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierHolderIntervalX() =
+    getPrintInterval(
+        finalUTurnCurvedBarrierHolderLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierHolderIntervalY() =
+    getPrintInterval(
+        finalUTurnCurvedBarrierHolderWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a U-turn curve.
+ */
+module finalUTurnCurvedBarrierHolder() {
     uTurnBarrierHolder(
         length = trackSectionLength,
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        gap = archTowerThickness * 2,
+        gap = finalUTurnCurvedBarrierHolderGap(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalUTurnCurvedBarrierHolder();
 }

--- a/rcmodels/tracks/parts/elements/straight/arch-tower.scad
+++ b/rcmodels/tracks/parts/elements/straight/arch-tower.scad
@@ -31,11 +31,54 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    distribute([0, getBarrierHolderWidth(barrierHolderBase) * 2, 0], center=true) {
+/**
+ * Gets the length of the final shape for a couple of arch towers (male and female)
+ * @returns Number
+ */
+function finalArchTowerLength() =
+    getArchTowerLengthMale(
+        length = trackSectionLength,
+        base = barrierHolderBase,
+        wall = archTowerThickness
+    )
+;
+
+/**
+ * Gets the width of the final shape for a couple of arch towers (male and female)
+ * @returns Number
+ */
+function finalArchTowerWidth() =
+    getArchTowerWidth(
+        base = barrierHolderBase,
+        wall = archTowerThickness
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a couple of arch towers (male and female)
+ * @returns Number
+ */
+function finalArchTowerIntervalX() =
+    getPrintInterval(
+        finalArchTowerLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a couple of arch towers (male and female)
+ * @returns Number
+ */
+function finalArchTowerIntervalY() =
+    2 * getPrintInterval(
+        finalArchTowerWidth()
+    )
+;
+
+/**
+ * Defines the final shapes for a couple of arch towers (male and female).
+ */
+module finalArchTower() {
+    distribute([0, finalArchTowerIntervalY() / 2, 0], center=true) {
         archTowerMale(
             length = trackSectionLength,
             thickness = barrierBodyThickness,
@@ -49,4 +92,11 @@ applyMode(mode=renderMode) {
             wall = archTowerThickness
         );
     }
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalArchTower();
 }

--- a/rcmodels/tracks/parts/elements/straight/body-curved.scad
+++ b/rcmodels/tracks/parts/elements/straight/body-curved.scad
@@ -31,15 +31,54 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the length of the final shape for the additional barrier body of a curve.
+ * @returns Number
+ */
+function finalCurvedBarrierBodyLength() = getCurveRemainingLength(trackSectionLength);
+
+/**
+ * Gets the width of the final shape for the additional barrier body of a curve.
+ * @returns Number
+ */
+function finalCurvedBarrierBodyWidth() = getBarrierBodyHeight(barrierHeight);
+
+/**
+ * Gets the width of the final shape for the additional barrier body of a curve.
+ * @returns Number
+ */
+function finalCurvedBarrierBodyIntervalX() =
+    getPrintInterval(
+        finalCurvedBarrierBodyLength()
+    )
+;
+
+/**
+ * Gets the width of the final shape for the additional barrier body of a curve.
+ * @returns Number
+ */
+function finalCurvedBarrierBodyIntervalY() =
+    getPrintInterval(
+        finalCurvedBarrierBodyWidth()
+    )
+;
+
+/**
+ * Defines the final shape for the additional barrier body of a curve.
+ */
+module finalCurvedBarrierBody() {
     barrierBody(
-        length = getCurveRemainingLength(trackSectionLength),
-        height = getBarrierBodyHeight(barrierHeight),
+        length = finalCurvedBarrierBodyLength(),
+        height = finalCurvedBarrierBodyWidth(),
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
         notches = 1
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalCurvedBarrierBody();
 }

--- a/rcmodels/tracks/parts/elements/straight/body-straight.scad
+++ b/rcmodels/tracks/parts/elements/straight/body-straight.scad
@@ -31,15 +31,54 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the length of the final shape for a barrier body.
+ * @returns Number
+ */
+function finalStraightBarrierBodyLength() = trackSectionLength;
+
+/**
+ * Gets the width of the final shape for a barrier body.
+ * @returns Number
+ */
+function finalStraightBarrierBodyWidth() = getBarrierBodyHeight(barrierHeight);
+
+/**
+ * Gets the horizontal interval of the final shape for a barrier body.
+ * @returns Number
+ */
+function finalStraightBarrierBodyIntervalX() =
+    getPrintInterval(
+        finalStraightBarrierBodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a barrier body.
+ * @returns Number
+ */
+function finalStraightBarrierBodyIntervalY() =
+    getPrintInterval(
+        finalStraightBarrierBodyWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a barrier body.
+ */
+module finalStraightBarrierBody() {
     barrierBody(
-        length = trackSectionLength,
-        height = getBarrierBodyHeight(barrierHeight),
+        length = finalStraightBarrierBodyLength(),
+        height = finalStraightBarrierBodyWidth(),
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
         notches = 2
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalStraightBarrierBody();
 }

--- a/rcmodels/tracks/parts/elements/straight/body-uturn.scad
+++ b/rcmodels/tracks/parts/elements/straight/body-uturn.scad
@@ -31,15 +31,66 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
+/**
+ * Gets the size of the gap between the 2 sides of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnBarrierBodyGap() = archTowerThickness * 2;
+
+/**
+ * Gets the length of the final shape for the additional barrier body of a U-turn.
+ * @returns Number
+ */
+function finalUTurnBarrierBodyLength() =
+    getUTurnCompensationBarrierBodyLength(
+        length = trackSectionLength,
+        base = barrierHolderBase,
+        gap = finalUTurnBarrierBodyGap()
+    )
+;
+
+/**
+ * Gets the width of the final shape for the additional barrier body of a U-turn.
+ * @returns Number
+ */
+function finalUTurnBarrierBodyWidth() = getBarrierBodyHeight(barrierHeight);
+
+/**
+ * Gets the horizontal interval of the final shape for the additional barrier body of a U-turn.
+ * @returns Number
+ */
+function finalUTurnBarrierBodyIntervalX() =
+    getPrintInterval(
+        finalUTurnBarrierBodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for the additional barrier body of a U-turn.
+ * @returns Number
+ */
+function finalUTurnBarrierBodyIntervalY() =
+    getPrintInterval(
+        finalUTurnBarrierBodyWidth()
+    )
+;
+
+/**
+ * Defines the final shape for the additional barrier body of a U-turn.
+ */
+module finalUTurnBarrierBody() {
+    uTurnCompensationBarrierBody(
+        length = finalUTurnBarrierBodyLength(),
+        height = finalUTurnBarrierBodyWidth(),
+        thickness = barrierBodyThickness,
+        base = barrierHolderBase,
+        gap = finalUTurnBarrierBodyGap()
+    );
+}
+
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    uTurnCompensationBarrierBody(
-        length = trackSectionLength,
-        height = getBarrierBodyHeight(barrierHeight),
-        thickness = barrierBodyThickness,
-        base = barrierHolderBase,
-        gap = archTowerThickness * 2
-    );
+    finalUTurnBarrierBody();
 }

--- a/rcmodels/tracks/parts/elements/straight/straight-double.scad
+++ b/rcmodels/tracks/parts/elements/straight/straight-double.scad
@@ -31,14 +31,65 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the length ratio of the final shape for a double length barrier holder.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierHolderRatio() = 2;
+
+/**
+ * Gets the length of the final shape for a double length barrier holder.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierHolderLength() =
+    getStraightBarrierLength(
+        length = trackSectionLength,
+        base = barrierHolderBase,
+        ratio = finalDoubleStraightBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a double length barrier holder.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierHolderWidth() = getBarrierHolderWidth(barrierHolderBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a double length barrier holder.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierHolderIntervalX() =
+    getPrintInterval(
+        finalDoubleStraightBarrierHolderLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a double length barrier holder.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierHolderIntervalY() =
+    getPrintInterval(
+        finalDoubleStraightBarrierHolderWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a double length barrier holder.
+ */
+module finalDoubleStraightBarrierHolder() {
     straightBarrierHolder(
         length = trackSectionLength,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = 2
+        ratio = finalDoubleStraightBarrierHolderRatio()
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalDoubleStraightBarrierHolder();
 }

--- a/rcmodels/tracks/parts/elements/straight/straight-simple.scad
+++ b/rcmodels/tracks/parts/elements/straight/straight-simple.scad
@@ -31,14 +31,65 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the length ratio of the final shape for a simple length barrier holder.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierHolderRatio() = 1;
+
+/**
+ * Gets the length of the final shape for a simple length barrier holder.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierHolderLength() =
+    getStraightBarrierLength(
+        length = trackSectionLength,
+        base = barrierHolderBase,
+        ratio = finalSimpleStraightBarrierHolderRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a simple length barrier holder.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierHolderWidth() = getBarrierHolderWidth(barrierHolderBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a simple length barrier holder.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierHolderIntervalX() =
+    getPrintInterval(
+        finalSimpleStraightBarrierHolderLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a simple length barrier holder.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierHolderIntervalY() =
+    getPrintInterval(
+        finalSimpleStraightBarrierHolderWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a simple length barrier holder.
+ */
+module finalSimpleStraightBarrierHolder() {
     straightBarrierHolder(
         length = trackSectionLength,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = 1
+        ratio = finalSimpleStraightBarrierHolderRatio()
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalSimpleStraightBarrierHolder();
 }

--- a/rcmodels/tracks/parts/elements/straight/straight-uturn.scad
+++ b/rcmodels/tracks/parts/elements/straight/straight-uturn.scad
@@ -31,13 +31,64 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
+/**
+ * Gets the size of the gap between the 2 sides of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierHolderGap() = archTowerThickness * 2;
+
+/**
+ * Gets the length of the final shape for a U-turn compensation barrier holder.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierHolderLength() =
+    getUTurnCompensationBarrierLength(
+        width = getBarrierHolderWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        gap = finalUTurnCompensationBarrierHolderGap()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a U-turn compensation barrier holder.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierHolderWidth() = getBarrierHolderWidth(barrierHolderBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a U-turn compensation barrier holder.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierHolderIntervalX() =
+    getPrintInterval(
+        finalUTurnCompensationBarrierHolderLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a U-turn compensation barrier holder.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierHolderIntervalY() =
+    getPrintInterval(
+        finalUTurnCompensationBarrierHolderWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a U-turn compensation barrier holder.
+ */
+module finalUTurnCompensationBarrierHolder() {
+    uTurnCompensationBarrierHolder(
+        thickness = barrierBodyThickness,
+        base = barrierHolderBase,
+        gap = finalUTurnCompensationBarrierHolderGap()
+    );
+}
+
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    uTurnCompensationBarrierHolder(
-        thickness = barrierBodyThickness,
-        base = barrierHolderBase,
-        gap = archTowerThickness * 2
-    );
+    finalUTurnCompensationBarrierHolder();
 }

--- a/rcmodels/tracks/parts/samples/curved/curved-inner-full.scad
+++ b/rcmodels/tracks/parts/samples/curved/curved-inner-full.scad
@@ -31,15 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalFullInnerCurvedBarrierSampleRatio() = getInnerCurveRatio(trackSectionLength, trackRadius);
+
+/**
+ * Gets the length of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalFullInnerCurvedBarrierSampleLength() =
+    getCurvedBarrierLength(
+        length = sampleSize * finalFullInnerCurvedBarrierSampleRatio(),
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = 1
+    )
+;
+
+/**
+ * Gets the width of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalFullInnerCurvedBarrierSampleWidth() =
+    getCurvedBarrierWidth(
+        length = sampleSize * finalFullInnerCurvedBarrierSampleRatio(),
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = 1
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalFullInnerCurvedBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalFullInnerCurvedBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalFullInnerCurvedBarrierSampleIntervalY() =
+    getPrintInterval(
+        getBarrierHolderWidth(sampleBase)
+    )
+;
+
+/**
+ * Defines the final shape for a full inner curve.
+ */
+module finalFullInnerCurvedBarrierSample() {
     curvedBarrierMain(
-        length = sampleSize * getInnerCurveRatio(trackSectionLength, trackRadius),
+        length = sampleSize * finalFullInnerCurvedBarrierSampleRatio(),
         thickness = barrierBodyThickness,
         base = sampleBase,
         ratio = 1,
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalFullInnerCurvedBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/curved/curved-inner.scad
+++ b/rcmodels/tracks/parts/samples/curved/curved-inner.scad
@@ -31,15 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierSampleRatio() = getInnerCurveRatio(trackSectionLength, trackRadius);
+
+/**
+ * Gets the length of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierSampleLength() =
+    getCurvedBarrierLength(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = finalInnerCurvedBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierSampleWidth() =
+    getCurvedBarrierWidth(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = finalInnerCurvedBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalInnerCurvedBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierSampleIntervalY() =
+    getPrintInterval(
+        getBarrierHolderWidth(sampleBase)
+    )
+;
+
+/**
+ * Defines the final shape for an inner curve.
+ */
+module finalInnerCurvedBarrierSample() {
     curvedBarrierMain(
         length = sampleSize,
         thickness = barrierBodyThickness,
         base = sampleBase,
-        ratio = getInnerCurveRatio(trackSectionLength, trackRadius),
+        ratio = finalInnerCurvedBarrierSampleRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalInnerCurvedBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/curved/curved-outer-full.scad
+++ b/rcmodels/tracks/parts/samples/curved/curved-outer-full.scad
@@ -31,15 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalFullOuterCurvedBarrierSampleRatio() = getOuterCurveRatio(trackSectionLength, trackSectionWidth, trackRadius);
+
+/**
+ * Gets the length of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalFullOuterCurvedBarrierSampleLength() =
+    getCurvedBarrierLength(
+        length = sampleSize * finalFullOuterCurvedBarrierSampleRatio(),
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = 1
+    )
+;
+
+/**
+ * Gets the width of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalFullOuterCurvedBarrierSampleWidth() =
+    getCurvedBarrierWidth(
+        length = sampleSize * finalFullOuterCurvedBarrierSampleRatio(),
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = 1
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalFullOuterCurvedBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalFullOuterCurvedBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalFullOuterCurvedBarrierSampleIntervalY() =
+    getPrintInterval(
+        getBarrierHolderWidth(sampleBase)
+    )
+;
+
+/**
+ * Defines the final shape for a full outer curve.
+ */
+module finalFullOuterCurvedBarrierSample() {
     curvedBarrierMain(
-        length = sampleSize * getOuterCurveRatio(trackSectionLength, trackSectionWidth, trackRadius),
+        length = sampleSize * finalFullOuterCurvedBarrierSampleRatio(),
         thickness = barrierBodyThickness,
         base = sampleBase,
         ratio = 1,
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalFullOuterCurvedBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/curved/curved-outer.scad
+++ b/rcmodels/tracks/parts/samples/curved/curved-outer.scad
@@ -31,15 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierSampleRatio() = getOuterCurveRatio(trackSectionLength, trackSectionWidth, trackRadius);
+
+/**
+ * Gets the length of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierSampleLength() =
+    getCurvedBarrierLength(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = finalOuterCurvedBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierSampleWidth() =
+    getCurvedBarrierWidth(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = finalOuterCurvedBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalOuterCurvedBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierSampleIntervalY() =
+    getPrintInterval(
+        getBarrierHolderWidth(sampleBase)
+    )
+;
+
+/**
+ * Defines the final shape for an outer curve.
+ */
+module finalOuterCurvedBarrierSample() {
     curvedBarrierMain(
         length = sampleSize,
         thickness = barrierBodyThickness,
         base = sampleBase,
-        ratio = getOuterCurveRatio(trackSectionLength, trackSectionWidth, trackRadius),
+        ratio = finalOuterCurvedBarrierSampleRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalOuterCurvedBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/curved/curved-short.scad
+++ b/rcmodels/tracks/parts/samples/curved/curved-short.scad
@@ -31,15 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an short curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierSampleRatio() = .5;
+
+/**
+ * Gets the length of the final shape for an short curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierSampleLength() =
+    getCurvedBarrierLength(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = finalShortCurvedBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an short curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierSampleWidth() =
+    getCurvedBarrierWidth(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = finalShortCurvedBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an short curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalShortCurvedBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an short curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierSampleIntervalY() =
+    getPrintInterval(
+        finalShortCurvedBarrierSampleWidth() / 2
+    )
+;
+
+/**
+ * Defines the final shape for a short curve.
+ */
+module finalShortCurvedBarrierSample() {
     curvedBarrierMain(
         length = sampleSize,
         thickness = barrierBodyThickness,
         base = sampleBase,
-        ratio = .5,
+        ratio = finalShortCurvedBarrierSampleRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalShortCurvedBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/curved/curved-small.scad
+++ b/rcmodels/tracks/parts/samples/curved/curved-small.scad
@@ -31,15 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierSampleRatio() = 1;
+
+/**
+ * Gets the length of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierSampleLength() =
+    getCurvedBarrierLength(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = finalSmallCurvedBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierSampleWidth() =
+    getCurvedBarrierWidth(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        ratio = finalSmallCurvedBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalSmallCurvedBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierSampleIntervalY() =
+    getPrintInterval(
+        finalSmallCurvedBarrierSampleWidth() / 2
+    )
+;
+
+/**
+ * Defines the final shape for a small curve.
+ */
+module finalSmallCurvedBarrierSample() {
     curvedBarrierMain(
         length = sampleSize,
         thickness = barrierBodyThickness,
         base = sampleBase,
-        ratio = 1,
+        ratio = finalSmallCurvedBarrierSampleRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalSmallCurvedBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/curved/curved-uturn.scad
+++ b/rcmodels/tracks/parts/samples/curved/curved-uturn.scad
@@ -32,11 +32,62 @@
 include <../../../config/setup.scad>
 
 /**
+ * Gets the size of the gap between the 2 sides of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierSampleGap() = minWidth * 2;
+
+/**
+ * Gets the length of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierSampleLength() =
+    getUTurnBarrierLength(
+        length = sampleSize,
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        gap = finalUTurnCurvedBarrierSampleGap()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierSampleWidth() =
+    getUTurnBarrierWidth(
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        gap = finalUTurnCurvedBarrierSampleGap()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalUTurnCurvedBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierSampleIntervalY() =
+    getPrintInterval(
+        finalUTurnCurvedBarrierSampleWidth()
+    )
+;
+
+/**
  * Draws the shape of a barrier border for a U-Turn.
  * @param Number length - The length of a track element.
  * @param Number thickness - The thickness of the barrier body.
  * @param Number base - The base unit value used to design the barrier holder.
- * @param Number gap - The distance between the two side of the u-turn.
+ * @param Number gap - The distance between the two side of the U-turn.
  * @param Number right - Is it the right or the left part of the track element that is added first?
  */
 module uTurnSample(length, thickness, base, gap, right = false) {
@@ -79,15 +130,22 @@ module uTurnSample(length, thickness, base, gap, right = false) {
     }
 }
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Defines the final shape for a U-turn curve.
+ */
+module finalUTurnCurvedBarrierSample() {
     uTurnSample(
         length = sampleSize,
         thickness = barrierBodyThickness,
         base = sampleBase,
-        gap = minWidth * 2,
+        gap = finalUTurnCurvedBarrierSampleGap(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalUTurnCurvedBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/straight/arch-sample.scad
+++ b/rcmodels/tracks/parts/samples/straight/arch-sample.scad
@@ -31,9 +31,57 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Refine the config for the arch sample
-laneWidth = trackLaneWidth / trackSectionLength * sampleSize;
-wallWidth = minWidth * 2;
+/**
+ * Gets the width of a lane with respect to the samples.
+ * @returns Number
+ */
+function getSampleLaneWidth() = trackLaneWidth / trackSectionLength * sampleSize;
+
+/**
+ * Gets the thickness of the clip outline..
+ * @returns Number
+ */
+function getSampleWallWidth() = minWidth * 2;
+
+/**
+ * Gets the length of the final shape for an arch sample.
+ * @returns Number
+ */
+function finalArchSampleLength() =
+    getSampleLaneWidth() +
+    getBarrierHolderWidth(sampleBase) +
+    getSampleWallWidth() * 2
+;
+
+/**
+ * Gets the width of the final shape for an arch sample.
+ * @returns Number
+ */
+function finalArchSampleWidth() =
+    sampleSize * 1.5 +
+    getBarrierHolderHeight(sampleBase) +
+    getSampleWallWidth() * 2
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an arch sample.
+ * @returns Number
+ */
+function finalArchSampleIntervalX() =
+    getPrintInterval(
+        finalArchSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an arch sample.
+ * @returns Number
+ */
+function finalArchSampleIntervalY() =
+    getPrintInterval(
+        finalArchSampleWidth()
+    )
+;
 
 /**
  * Computes the points defining the profile of the arch sample.
@@ -66,6 +114,7 @@ function getArchSamplePoints(length, width) =
  */
 module archSampleProfile(length, width, wall) {
     distance = wall / 2;
+
     difference() {
         polygon(outline(getArchSamplePoints(length, width), -distance), convexity = 10);
         polygon(outline(getArchSamplePoints(length, width), distance), convexity = 10);
@@ -73,11 +122,14 @@ module archSampleProfile(length, width, wall) {
     }
 }
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    negativeExtrude(height=getBarrierHolderWidth(sampleBase)) {
+/**
+ * Defines the final shape for an arch sample.
+ */
+module finalArchSample() {
+    laneWidth = getSampleLaneWidth();
+    wallWidth = getSampleWallWidth();
+
+    linear_extrude(height=getBarrierHolderWidth(sampleBase), convexity=10) {
         archSampleProfile(sampleSize, laneWidth, wallWidth);
         repeat(count=2, intervalX=laneWidth, center=true) {
             translateY(-getBarrierHolderHeight(sampleBase) - wallWidth * 2) {
@@ -94,4 +146,11 @@ applyMode(mode=renderMode) {
             }
         }
     }
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalArchSample();
 }

--- a/rcmodels/tracks/parts/samples/straight/straight-double.scad
+++ b/rcmodels/tracks/parts/samples/straight/straight-double.scad
@@ -31,13 +31,64 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
+/**
+ * Gets the length ratio of the final shape for a double length barrier sample.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierSampleRatio() = 2;
+
+/**
+ * Gets the length of the final shape for a double length barrier sample.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierSampleLength() =
+    getStraightBarrierLength(
+        length = sampleSize,
+        base = sampleBase,
+        ratio = finalDoubleStraightBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a double length barrier sample.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierSampleWidth() = getBarrierHolderWidth(sampleBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a double length barrier sample.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalDoubleStraightBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a double length barrier sample.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierSampleIntervalY() =
+    getPrintInterval(
+        finalDoubleStraightBarrierSampleWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a double length barrier sample.
+ */
+module finalDoubleStraightBarrierSample() {
+    straightBarrierMain(
+        length = sampleSize * finalDoubleStraightBarrierSampleRatio(),
+        thickness = barrierBodyThickness,
+        base = sampleBase
+    );
+}
+
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    straightBarrierMain(
-        length = sampleSize * 2,
-        thickness = barrierBodyThickness,
-        base = sampleBase
-    );
+    finalDoubleStraightBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/straight/straight-long.scad
+++ b/rcmodels/tracks/parts/samples/straight/straight-long.scad
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A sample for a straight track part, 10x the length.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+
+/**
+ * Gets the length ratio of the final shape for a long length barrier sample.
+ * @returns Number
+ */
+function finalLongStraightBarrierSampleRatio() = 10;
+
+/**
+ * Gets the length of the final shape for a long length barrier sample.
+ * @returns Number
+ */
+function finalLongStraightBarrierSampleLength() =
+    getStraightBarrierLength(
+        length = sampleSize,
+        base = sampleBase,
+        ratio = finalLongStraightBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a long length barrier sample.
+ * @returns Number
+ */
+function finalLongStraightBarrierSampleWidth() = getBarrierHolderWidth(sampleBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a long length barrier sample.
+ * @returns Number
+ */
+function finalLongStraightBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalLongStraightBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a long length barrier sample.
+ * @returns Number
+ */
+function finalLongStraightBarrierSampleIntervalY() =
+    getPrintInterval(
+        finalLongStraightBarrierSampleWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a long length barrier sample.
+ */
+module finalLongStraightBarrierSample() {
+    straightBarrierMain(
+        length = sampleSize * finalLongStraightBarrierSampleRatio(),
+        thickness = barrierBodyThickness,
+        base = sampleBase
+    );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalLongStraightBarrierSample();
+}

--- a/rcmodels/tracks/parts/samples/straight/straight-simple.scad
+++ b/rcmodels/tracks/parts/samples/straight/straight-simple.scad
@@ -31,13 +31,64 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
+/**
+ * Gets the length ratio of the final shape for a simple length barrier sample.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierSampleRatio() = 1;
+
+/**
+ * Gets the length of the final shape for a simple length barrier sample.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierSampleLength() =
+    getStraightBarrierLength(
+        length = sampleSize,
+        base = sampleBase,
+        ratio = finalSimpleStraightBarrierSampleRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a simple length barrier sample.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierSampleWidth() = getBarrierHolderWidth(sampleBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a simple length barrier sample.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalSimpleStraightBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a simple length barrier sample.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierSampleIntervalY() =
+    getPrintInterval(
+        finalSimpleStraightBarrierSampleWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a simple length barrier sample.
+ */
+module finalSimpleStraightBarrierSample() {
+    straightBarrierMain(
+        length = sampleSize * finalSimpleStraightBarrierSampleRatio(),
+        thickness = barrierBodyThickness,
+        base = sampleBase
+    );
+}
+
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    straightBarrierMain(
-        length = sampleSize,
-        thickness = barrierBodyThickness,
-        base = sampleBase
-    );
+    finalSimpleStraightBarrierSample();
 }

--- a/rcmodels/tracks/parts/samples/straight/straight-uturn.scad
+++ b/rcmodels/tracks/parts/samples/straight/straight-uturn.scad
@@ -31,13 +31,64 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
+/**
+ * Gets the size of the gap between the 2 sides of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierSampleGap() = minWidth * 2;
+
+/**
+ * Gets the length of the final shape for a U-turn compensation barrier sample.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierSampleLength() =
+    getUTurnCompensationBarrierLength(
+        width = getBarrierHolderWidth(sampleBase),
+        base = sampleBase,
+        gap = finalUTurnCompensationBarrierSampleGap()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a U-turn compensation barrier sample.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierSampleWidth() = getBarrierHolderWidth(sampleBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a U-turn compensation barrier sample.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierSampleIntervalX() =
+    getPrintInterval(
+        finalUTurnCompensationBarrierSampleLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a U-turn compensation barrier sample.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierSampleIntervalY() =
+    getPrintInterval(
+        finalUTurnCompensationBarrierSampleWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a U-turn compensation barrier sample.
+ */
+module finalUTurnCompensationBarrierSample() {
+    straightBarrierMain(
+        length = getBarrierHolderWidth(sampleBase) + finalUTurnCompensationBarrierSampleGap(),
+        thickness = barrierBodyThickness,
+        base = sampleBase
+    );
+}
+
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    straightBarrierMain(
-        length = getBarrierHolderWidth(sampleBase) + minWidth * 2,
-        thickness = barrierBodyThickness,
-        base = sampleBase
-    );
+    finalUTurnCompensationBarrierSample();
 }

--- a/rcmodels/tracks/parts/unibody/curved/curved-inner.scad
+++ b/rcmodels/tracks/parts/unibody/curved/curved-inner.scad
@@ -31,16 +31,75 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierUnibodyRatio() = getInnerCurveRatio(trackSectionLength, trackRadius);
+
+/**
+ * Gets the length of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierUnibodyLength() =
+    getCurvedBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalInnerCurvedBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierUnibodyWidth() =
+    getCurvedBarrierWidth(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalInnerCurvedBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalInnerCurvedBarrierUnibodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an inner curve.
+ * @returns Number
+ */
+function finalInnerCurvedBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        getBarrierUnibodyWidth(barrierHolderBase)
+    )
+;
+
+/**
+ * Defines the final shape for an inner curve.
+ */
+module finalInnerCurvedBarrierUnibody() {
     curvedBarrierUnibody(
         length = trackSectionLength,
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = getInnerCurveRatio(trackSectionLength, trackRadius),
+        ratio = finalInnerCurvedBarrierUnibodyRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalInnerCurvedBarrierUnibody();
 }

--- a/rcmodels/tracks/parts/unibody/curved/curved-outer.scad
+++ b/rcmodels/tracks/parts/unibody/curved/curved-outer.scad
@@ -31,16 +31,75 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierUnibodyRatio() = getOuterCurveRatio(trackSectionLength, trackSectionWidth, trackRadius);
+
+/**
+ * Gets the length of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierUnibodyLength() =
+    getCurvedBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalOuterCurvedBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierUnibodyWidth() =
+    getCurvedBarrierWidth(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalOuterCurvedBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalOuterCurvedBarrierUnibodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an outer curve.
+ * @returns Number
+ */
+function finalOuterCurvedBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        getBarrierUnibodyWidth(barrierHolderBase)
+    )
+;
+
+/**
+ * Defines the final shape for an outer curve.
+ */
+module finalOuterCurvedBarrierUnibody() {
     curvedBarrierUnibody(
         length = trackSectionLength,
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = getOuterCurveRatio(trackSectionLength, trackSectionWidth, trackRadius),
+        ratio = finalOuterCurvedBarrierUnibodyRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalOuterCurvedBarrierUnibody();
 }

--- a/rcmodels/tracks/parts/unibody/curved/curved-short.scad
+++ b/rcmodels/tracks/parts/unibody/curved/curved-short.scad
@@ -31,16 +31,76 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierUnibodyRatio() = .5;
+
+/**
+ * Gets the length of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierUnibodyLength() =
+    getCurvedBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalShortCurvedBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierUnibodyWidth() =
+    getCurvedBarrierWidth(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalShortCurvedBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalShortCurvedBarrierUnibodyLength() / 4
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalShortCurvedBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        getBarrierUnibodyWidth(barrierHolderBase) +
+        getBarrierLinkLength(barrierHolderBase)
+    )
+;
+
+/**
+ * Defines the final shape for a short curve.
+ */
+module finalShortCurvedBarrierUnibody() {
     curvedBarrierUnibody(
         length = trackSectionLength,
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = .5,
+        ratio = finalShortCurvedBarrierUnibodyRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalShortCurvedBarrierUnibody();
 }

--- a/rcmodels/tracks/parts/unibody/curved/curved-small.scad
+++ b/rcmodels/tracks/parts/unibody/curved/curved-small.scad
@@ -31,16 +31,76 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the curve ratio of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierUnibodyRatio() = 1;
+
+/**
+ * Gets the length of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierUnibodyLength() =
+    getCurvedBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalSmallCurvedBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierUnibodyWidth() =
+    getCurvedBarrierWidth(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        ratio = finalSmallCurvedBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalSmallCurvedBarrierUnibodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for an small curve.
+ * @returns Number
+ */
+function finalSmallCurvedBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        getBarrierUnibodyWidth(barrierHolderBase) +
+        getBarrierLinkLength(barrierHolderBase)
+    )
+;
+
+/**
+ * Defines the final shape for a small curve.
+ */
+module finalSmallCurvedBarrierUnibody() {
     curvedBarrierUnibody(
         length = trackSectionLength,
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        ratio = 1,
+        ratio = finalSmallCurvedBarrierUnibodyRatio(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalSmallCurvedBarrierUnibody();
 }

--- a/rcmodels/tracks/parts/unibody/curved/curved-uturn.scad
+++ b/rcmodels/tracks/parts/unibody/curved/curved-uturn.scad
@@ -31,16 +31,74 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the size of the gap between the 2 sides of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierUnibodyGap() = archTowerThickness * 2;
+
+/**
+ * Gets the length of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierUnibodyLength() =
+    getUTurnBarrierLength(
+        length = trackSectionLength,
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        gap = finalUTurnCurvedBarrierUnibodyGap()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierUnibodyWidth() =
+    getUTurnBarrierWidth(
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        gap = finalUTurnCurvedBarrierUnibodyGap()
+    )
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalUTurnCurvedBarrierUnibodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCurvedBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        finalUTurnCurvedBarrierUnibodyWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a U-turn curve.
+ */
+module finalUTurnCurvedBarrierUnibody() {
     uTurnBarrierUnibody(
         length = trackSectionLength,
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        gap = archTowerThickness * 2,
+        gap = finalUTurnCurvedBarrierUnibodyGap(),
         right = rightOriented
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalUTurnCurvedBarrierUnibody();
 }

--- a/rcmodels/tracks/parts/unibody/straight/straight-connector.scad
+++ b/rcmodels/tracks/parts/unibody/straight/straight-connector.scad
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A unibody barrier connector to connect track part made with barrier holder.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+
+/**
+ * Gets the length of the final shape for a unibody barrier connector.
+ * @returns Number
+ */
+function finalConnectorBarrierUnibodyLength() =
+    2 * getStraightBarrierLength(trackSectionLength, barrierHolderBase, .5) +
+    getBarrierLinkLength(barrierHolderBase) +
+    printInterval
+;
+
+/**
+ * Gets the width of the final shape for a unibody barrier connector.
+ * @returns Number
+ */
+function finalConnectorBarrierUnibodyWidth() =
+    3 * getBarrierUnibodyWidth(barrierHolderBase) +
+    2 * printInterval
+;
+
+/**
+ * Gets the horizontal interval of the final shape for a unibody barrier connector.
+ * @returns Number
+ */
+function finalConnectorBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalConnectorBarrierUnibodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a unibody barrier connector.
+ * @returns Number
+ */
+function finalConnectorBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        finalConnectorBarrierUnibodyWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a unibody barrier connector.
+ */
+module finalConnectorBarrierUnibody() {
+    intervalX = getPrintInterval(getStraightBarrierLength(trackSectionLength, barrierHolderBase, .5));
+    intervalY = getPrintInterval(getBarrierUnibodyWidth(barrierHolderBase));
+    distribute(intervalY=intervalY, center=true) {
+        barrierHolderToUnibodyMale(
+            length = trackSectionLength,
+            height = barrierHeight,
+            thickness = barrierBodyThickness,
+            base = barrierHolderBase
+        );
+        distribute(intervalX=intervalX, center=true) {
+            barrierHolderConnectorFemale(
+                length = trackSectionLength,
+                thickness = barrierBodyThickness,
+                base = barrierHolderBase
+            );
+            barrierHolderConnectorMale(
+                length = trackSectionLength,
+                thickness = barrierBodyThickness,
+                base = barrierHolderBase
+            );
+        }
+        barrierHolderToUnibodyFemale(
+            length = trackSectionLength,
+            height = barrierHeight,
+            thickness = barrierBodyThickness,
+            base = barrierHolderBase
+        );
+    }
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalConnectorBarrierUnibody();
+}

--- a/rcmodels/tracks/parts/unibody/straight/straight-double.scad
+++ b/rcmodels/tracks/parts/unibody/straight/straight-double.scad
@@ -31,14 +31,65 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the length ratio of the final shape for a double length unibody barrier.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierUnibodyRatio() = 2;
+
+/**
+ * Gets the length of the final shape for a double length unibody barrier.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierUnibodyLength() =
+    getStraightBarrierLength(
+        length = trackSectionLength,
+        base = barrierHolderBase,
+        ratio = finalDoubleStraightBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a double length unibody barrier.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierUnibodyWidth() = getBarrierUnibodyWidth(barrierHolderBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a double length unibody barrier.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalDoubleStraightBarrierUnibodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a double length unibody barrier.
+ * @returns Number
+ */
+function finalDoubleStraightBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        finalDoubleStraightBarrierUnibodyWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a double length unibody barrier.
+ */
+module finalDoubleStraightBarrierUnibody() {
     straightBarrierUnibody(
-        length = trackSectionLength * 2,
+        length = trackSectionLength * finalDoubleStraightBarrierUnibodyRatio(),
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalDoubleStraightBarrierUnibody();
 }

--- a/rcmodels/tracks/parts/unibody/straight/straight-simple.scad
+++ b/rcmodels/tracks/parts/unibody/straight/straight-simple.scad
@@ -31,14 +31,65 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    straightBarrierUnibody(
+/**
+ * Gets the length ratio of the final shape for a simple length unibody barrier.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierUnibodyRatio() = 1;
+
+/**
+ * Gets the length of the final shape for a simple length unibody barrier.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierUnibodyLength() =
+    getStraightBarrierLength(
         length = trackSectionLength,
+        base = barrierHolderBase,
+        ratio = finalSimpleStraightBarrierUnibodyRatio()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a simple length unibody barrier.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierUnibodyWidth() = getBarrierUnibodyWidth(barrierHolderBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a simple length unibody barrier.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalSimpleStraightBarrierUnibodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a simple length unibody barrier.
+ * @returns Number
+ */
+function finalSimpleStraightBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        finalSimpleStraightBarrierUnibodyWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a simple length unibody barrier.
+ */
+module finalSimpleStraightBarrierUnibody() {
+    straightBarrierUnibody(
+        length = trackSectionLength * finalSimpleStraightBarrierUnibodyRatio(),
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalSimpleStraightBarrierUnibody();
 }

--- a/rcmodels/tracks/parts/unibody/straight/straight-uturn.scad
+++ b/rcmodels/tracks/parts/unibody/straight/straight-uturn.scad
@@ -31,14 +31,65 @@
 // Import the project's setup.
 include <../../../config/setup.scad>
 
-// Sets the minimum facet angle and size using the defined render mode.
-applyMode(mode=renderMode) {
-    // Uncomment the next line to cut a sample from the object
-    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+/**
+ * Gets the size of the gap between the 2 sides of the final shape for a U-turn curve.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierUnibodyGap() = archTowerThickness * 2;
+
+/**
+ * Gets the length of the final shape for a U-turn compensation unibody barrier.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierUnibodyLength() =
+    getUTurnCompensationBarrierLength(
+        width = getBarrierUnibodyWidth(barrierHolderBase),
+        base = barrierHolderBase,
+        gap = finalUTurnCompensationBarrierUnibodyGap()
+    )
+;
+
+/**
+ * Gets the width of the final shape for a U-turn compensation unibody barrier.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierUnibodyWidth() = getBarrierUnibodyWidth(barrierHolderBase);
+
+/**
+ * Gets the horizontal interval of the final shape for a U-turn compensation unibody barrier.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierUnibodyIntervalX() =
+    getPrintInterval(
+        finalUTurnCompensationBarrierUnibodyLength()
+    )
+;
+
+/**
+ * Gets the vertical interval of the final shape for a U-turn compensation unibody barrier.
+ * @returns Number
+ */
+function finalUTurnCompensationBarrierUnibodyIntervalY() =
+    getPrintInterval(
+        finalUTurnCompensationBarrierUnibodyWidth()
+    )
+;
+
+/**
+ * Defines the final shape for a U-turn compensation unibody barrier.
+ */
+module finalUTurnCompensationBarrierUnibody() {
     uTurnCompensationBarrierUnibody(
         height = barrierHeight,
         thickness = barrierBodyThickness,
         base = barrierHolderBase,
-        gap = archTowerThickness * 2
+        gap = finalUTurnCompensationBarrierUnibodyGap()
     );
+}
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    finalUTurnCompensationBarrierUnibody();
 }

--- a/rcmodels/tracks/plates/accessories/bent-mast.scad
+++ b/rcmodels/tracks/plates/accessories/bent-mast.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of bent masts to clip accessories onto the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+use <../../parts/accessories/bent-mast.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 2,
+            countY = 5,
+            intervalX = [finalBentMastIntervalX(), 0, 0],
+            intervalY = [0, finalBentMastIntervalY(), 0],
+            center = true
+        ) {
+            finalBentMast();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/accessories/cable-clip.scad
+++ b/rcmodels/tracks/plates/accessories/cable-clip.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of LED cable clips for the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+use <../../parts/accessories/cable-clip.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 15,
+            countY = 10,
+            intervalX = [finalCableClipIntervalX(), 0, 0],
+            intervalY = [0, finalCableClipIntervalY(), 0],
+            center = true
+        ) {
+            finalCableClip();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/accessories/straight-flag.scad
+++ b/rcmodels/tracks/plates/accessories/straight-flag.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight flags to clip onto the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+use <../../parts/accessories/straight-flag.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 3,
+            countY = 4,
+            intervalX = [finalStraightFlagIntervalX(), 0, 0],
+            intervalY = [0, finalStraightFlagIntervalY(), 0],
+            center = true
+        ) {
+            finalStraightFlag();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/accessories/straight-mast.scad
+++ b/rcmodels/tracks/plates/accessories/straight-mast.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of masts to clip accessories onto the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+use <../../parts/accessories/straight-mast.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 2,
+            countY = 10,
+            intervalX = [finalStraightMastIntervalX(), 0, 0],
+            intervalY = [0, finalStraightMastIntervalY(), 0],
+            center = true
+        ) {
+            finalStraightMast();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/accessories/wavy-flag.scad
+++ b/rcmodels/tracks/plates/accessories/wavy-flag.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight flags to clip onto the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../config/setup.scad>
+use <../../parts/accessories/wavy-flag.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 3,
+            countY = 4,
+            intervalX = [finalWavyFlagIntervalX(), 0, 0],
+            intervalY = [0, finalWavyFlagIntervalY(), 0],
+            center = true
+        ) {
+            finalWavyFlag();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/curved/curved-inner.scad
+++ b/rcmodels/tracks/plates/elements/curved/curved-inner.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier holders for an inner curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/curved/curved-inner.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = finalInnerCurvedBarrierHolderRatio() * 2,
+            intervalY = finalInnerCurvedBarrierHolderIntervalY(),
+            center = true
+        ) {
+            finalInnerCurvedBarrierHolder();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/curved/curved-outer.scad
+++ b/rcmodels/tracks/plates/elements/curved/curved-outer.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier holders for an outer curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/curved/curved-outer.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = finalOuterCurvedBarrierHolderRatio() * 2,
+            intervalY = finalOuterCurvedBarrierHolderIntervalY(),
+            center = true
+        ) {
+            finalOuterCurvedBarrierHolder();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/curved/curved-short.scad
+++ b/rcmodels/tracks/plates/elements/curved/curved-short.scad
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier holders for a short curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/curved/curved-short.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 2,
+            intervalY = finalShortCurvedBarrierHolderWidth() + finalShortCurvedBarrierHolderIntervalY(),
+            center = true
+        ) {
+            repeatRotate(
+                count = 2,
+                intervalX = finalShortCurvedBarrierHolderIntervalX(),
+                intervalY = -finalShortCurvedBarrierHolderIntervalY(),
+                center = true
+            ) {
+                finalShortCurvedBarrierHolder();
+            }
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/curved/curved-small.scad
+++ b/rcmodels/tracks/plates/elements/curved/curved-small.scad
@@ -23,21 +23,26 @@
 /**
  * A race track system for 1/24 to 1/32 scale RC cars.
  *
- * A sample for a straight track part, 20x the length.
+ * A print plate presenting a set of barrier holders for a small curve track part.
  *
  * @author jsconan
  */
 
 // Import the project's setup.
 include <../../../config/setup.scad>
+use <../../../parts/elements/curved/curved-small.scad>
 
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    straightBarrierMain(
-        length = sampleSize * 20,
-        thickness = barrierBodyThickness,
-        base = sampleBase
-    );
+    centerBuildPlate() {
+        repeat(
+            count = 4,
+            intervalY = finalSmallCurvedBarrierHolderIntervalY(),
+            center = true
+        ) {
+            finalSmallCurvedBarrierHolder();
+        }
+    }
 }

--- a/rcmodels/tracks/plates/elements/curved/curved-uturn.scad
+++ b/rcmodels/tracks/plates/elements/curved/curved-uturn.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier holders for a U-turn track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/curved/curved-uturn.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 4,
+            intervalY = finalUTurnCurvedBarrierHolderIntervalY(),
+            center = true
+        ) {
+            finalUTurnCurvedBarrierHolder();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/straight/arch-tower.scad
+++ b/rcmodels/tracks/plates/elements/straight/arch-tower.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of couples of arch towers that clamp the barrier holders.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/straight/arch-tower.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 2,
+            countY = 4,
+            intervalX = [finalArchTowerIntervalX(), 0, 0],
+            intervalY = [0, finalArchTowerIntervalY(), 0],
+            center = true
+        ) {
+            finalArchTower();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/straight/body-curved.scad
+++ b/rcmodels/tracks/plates/elements/straight/body-curved.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of additional barrier bodies for curved track parts.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/straight/body-curved.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 3,
+            countY = 5,
+            intervalX = [finalCurvedBarrierBodyIntervalX(), 0, 0],
+            intervalY = [0, finalCurvedBarrierBodyIntervalY(), 0],
+            center = true
+        ) {
+            finalCurvedBarrierBody();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/straight/body-straight.scad
+++ b/rcmodels/tracks/plates/elements/straight/body-straight.scad
@@ -23,21 +23,28 @@
 /**
  * A race track system for 1/24 to 1/32 scale RC cars.
  *
- * A sample for a straight track part, 5x the length.
+ * A print plate presenting a set of barrier bodies for straight track parts.
  *
  * @author jsconan
  */
 
 // Import the project's setup.
 include <../../../config/setup.scad>
+use <../../../parts/elements/straight/body-straight.scad>
 
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    straightBarrierMain(
-        length = sampleSize * 5,
-        thickness = barrierBodyThickness,
-        base = sampleBase
-    );
+    centerBuildPlate() {
+        repeat2D(
+            countX = 2,
+            countY = 5,
+            intervalX = [finalStraightBarrierBodyIntervalX(), 0, 0],
+            intervalY = [0, finalStraightBarrierBodyIntervalY(), 0],
+            center = true
+        ) {
+            finalStraightBarrierBody();
+        }
+    }
 }

--- a/rcmodels/tracks/plates/elements/straight/body-uturn.scad
+++ b/rcmodels/tracks/plates/elements/straight/body-uturn.scad
@@ -23,23 +23,26 @@
 /**
  * A race track system for 1/24 to 1/32 scale RC cars.
  *
- * A mast to clip accessories onto the barrier holders.
+ * A print plate presenting a set of additional barrier bodies for U-turn compensation track parts.
  *
  * @author jsconan
  */
 
 // Import the project's setup.
-include <../../config/setup.scad>
+include <../../../config/setup.scad>
+use <../../../parts/elements/straight/body-uturn.scad>
 
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    accessoryMast(
-        width = mastWidth,
-        height = mastHeight,
-        wall = accessoryClipThickness,
-        base = barrierHolderBase,
-        thickness = barrierBodyThickness
-    );
+    centerBuildPlate() {
+        repeat(
+            count = 5,
+            intervalY = finalUTurnBarrierBodyIntervalY(),
+            center = true
+        ) {
+            finalUTurnBarrierBody();
+        }
+    }
 }

--- a/rcmodels/tracks/plates/elements/straight/straight-double.scad
+++ b/rcmodels/tracks/plates/elements/straight/straight-double.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight barrier holders with a double length.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/straight/straight-double.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 10,
+            intervalY = finalDoubleStraightBarrierHolderIntervalY(),
+            center = true
+        ) {
+            finalDoubleStraightBarrierHolder();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/straight/straight-simple.scad
+++ b/rcmodels/tracks/plates/elements/straight/straight-simple.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight barrier holders with a simple length.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/straight/straight-simple.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 10,
+            intervalY = finalSimpleStraightBarrierHolderIntervalY(),
+            center = true
+        ) {
+            finalSimpleStraightBarrierHolder();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/elements/straight/straight-uturn.scad
+++ b/rcmodels/tracks/plates/elements/straight/straight-uturn.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight barrier holders to compensate a U-turn track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/elements/straight/straight-uturn.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = 5,
+            intervalX = [finalUTurnCompensationBarrierHolderIntervalX(), 0, 0],
+            intervalY = [0, finalUTurnCompensationBarrierHolderIntervalY(), 0],
+            center = true
+        ) {
+            finalUTurnCompensationBarrierHolder();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/curved/curved-inner-full.scad
+++ b/rcmodels/tracks/plates/samples/curved/curved-inner-full.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier samples for a full inner curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/curved/curved-inner-full.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = 4,
+            intervalX = [finalFullInnerCurvedBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalFullInnerCurvedBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalFullInnerCurvedBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/curved/curved-inner.scad
+++ b/rcmodels/tracks/plates/samples/curved/curved-inner.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier samples for an inner curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/curved/curved-inner.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = finalInnerCurvedBarrierSampleRatio() * 2,
+            intervalX = [finalInnerCurvedBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalInnerCurvedBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalInnerCurvedBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/curved/curved-outer-full.scad
+++ b/rcmodels/tracks/plates/samples/curved/curved-outer-full.scad
@@ -23,23 +23,28 @@
 /**
  * A race track system for 1/24 to 1/32 scale RC cars.
  *
- * A straight flag to clip onto the barrier holders.
+ * A print plate presenting a set of barrier samples for a full outer curve track part.
  *
  * @author jsconan
  */
 
 // Import the project's setup.
-include <../../config/setup.scad>
+include <../../../config/setup.scad>
+use <../../../parts/samples/curved/curved-outer-full.scad>
 
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    accessoryFlag(
-        width = flagWidth,
-        height = flagHeight,
-        thickness = flagThickness,
-        mast = mastWidth,
-        wave = 0
-    );
+    centerBuildPlate() {
+        repeat2D(
+            countX = 2,
+            countY = 8,
+            intervalX = [finalFullOuterCurvedBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalFullOuterCurvedBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalFullOuterCurvedBarrierSample();
+        }
+    }
 }

--- a/rcmodels/tracks/plates/samples/curved/curved-outer.scad
+++ b/rcmodels/tracks/plates/samples/curved/curved-outer.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier samples for an outer curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/curved/curved-outer.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = finalOuterCurvedBarrierSampleRatio(),
+            intervalX = [finalOuterCurvedBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalOuterCurvedBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalOuterCurvedBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/curved/curved-short.scad
+++ b/rcmodels/tracks/plates/samples/curved/curved-short.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier samples for a short curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/curved/curved-short.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = 4,
+            intervalX = [finalShortCurvedBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalShortCurvedBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalShortCurvedBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/curved/curved-small.scad
+++ b/rcmodels/tracks/plates/samples/curved/curved-small.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier samples for a small curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/curved/curved-small.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = 4,
+            intervalX = [finalSmallCurvedBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalSmallCurvedBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalSmallCurvedBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/curved/curved-uturn.scad
+++ b/rcmodels/tracks/plates/samples/curved/curved-uturn.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of barrier samples for a U-turn curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/curved/curved-uturn.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = 4,
+            intervalX = [finalUTurnCurvedBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalUTurnCurvedBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalUTurnCurvedBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/straight/arch-sample.scad
+++ b/rcmodels/tracks/plates/samples/straight/arch-sample.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of arch samples.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/straight/arch-sample.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 3,
+            countY = 4,
+            intervalX = [finalArchSampleIntervalX(), 0, 0],
+            intervalY = [0, finalArchSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalArchSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/straight/straight-double.scad
+++ b/rcmodels/tracks/plates/samples/straight/straight-double.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight barrier samples with a double length.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/straight/straight-double.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = 5,
+            intervalX = [finalDoubleStraightBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalDoubleStraightBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalDoubleStraightBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/straight/straight-long.scad
+++ b/rcmodels/tracks/plates/samples/straight/straight-long.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight barrier samples with 10x the length.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/straight/straight-long.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 10,
+            intervalY = finalLongStraightBarrierSampleIntervalY(),
+            center = true
+        ) {
+            finalLongStraightBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/straight/straight-simple.scad
+++ b/rcmodels/tracks/plates/samples/straight/straight-simple.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight barrier samples with a simple length.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/straight/straight-simple.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = 5,
+            intervalX = [finalSimpleStraightBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalSimpleStraightBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalSimpleStraightBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/samples/straight/straight-uturn.scad
+++ b/rcmodels/tracks/plates/samples/straight/straight-uturn.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight barrier samples for a U-turn compensation track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/samples/straight/straight-uturn.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 4,
+            countY = 5,
+            intervalX = [finalUTurnCompensationBarrierSampleIntervalX(), 0, 0],
+            intervalY = [0, finalUTurnCompensationBarrierSampleIntervalY(), 0],
+            center = true
+        ) {
+            finalUTurnCompensationBarrierSample();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/unibody/curved/curved-inner.scad
+++ b/rcmodels/tracks/plates/unibody/curved/curved-inner.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of unibody barriers for an inner curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/unibody/curved/curved-inner.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = finalInnerCurvedBarrierUnibodyRatio() * 2,
+            intervalY = finalInnerCurvedBarrierUnibodyIntervalY(),
+            center = true
+        ) {
+            finalInnerCurvedBarrierUnibody();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/unibody/curved/curved-outer.scad
+++ b/rcmodels/tracks/plates/unibody/curved/curved-outer.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of unibody barriers for an outer curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/unibody/curved/curved-outer.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = finalOuterCurvedBarrierUnibodyRatio(),
+            intervalY = finalOuterCurvedBarrierUnibodyIntervalY(),
+            center = true
+        ) {
+            finalOuterCurvedBarrierUnibody();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/unibody/curved/curved-short.scad
+++ b/rcmodels/tracks/plates/unibody/curved/curved-short.scad
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of unibody barriers for a short curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/unibody/curved/curved-short.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 2,
+            intervalY = finalShortCurvedBarrierUnibodyWidth() + finalShortCurvedBarrierUnibodyIntervalY(),
+            center = true
+        ) {
+            repeatRotate(
+                count = 2,
+                intervalX = finalShortCurvedBarrierUnibodyIntervalX(),
+                intervalY = -finalShortCurvedBarrierUnibodyIntervalY(),
+                center = true
+            ) {
+                finalShortCurvedBarrierUnibody();
+            }
+        }
+    }
+}

--- a/rcmodels/tracks/plates/unibody/curved/curved-small.scad
+++ b/rcmodels/tracks/plates/unibody/curved/curved-small.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of unibody barriers for a small curve track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/unibody/curved/curved-small.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 4,
+            intervalY = finalSmallCurvedBarrierUnibodyIntervalY(),
+            center = true
+        ) {
+            finalSmallCurvedBarrierUnibody();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/unibody/curved/curved-uturn.scad
+++ b/rcmodels/tracks/plates/unibody/curved/curved-uturn.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of unibody barriers for a U-turn track part.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/unibody/curved/curved-uturn.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 4,
+            intervalY = finalUTurnCurvedBarrierUnibodyIntervalY(),
+            center = true
+        ) {
+            finalUTurnCurvedBarrierUnibody();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/unibody/straight/straight-connector.scad
+++ b/rcmodels/tracks/plates/unibody/straight/straight-connector.scad
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of unibody barrier connectors to connect a track part made with barrier holder.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/unibody/straight/straight-connector.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat2D(
+            countX = 2,
+            countY = 2,
+            intervalX = [finalConnectorBarrierUnibodyIntervalX(), 0, 0],
+            intervalY = [0, finalConnectorBarrierUnibodyIntervalY(), 0],
+            center = true
+        ) {
+            finalConnectorBarrierUnibody();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/unibody/straight/straight-double.scad
+++ b/rcmodels/tracks/plates/unibody/straight/straight-double.scad
@@ -23,23 +23,27 @@
 /**
  * A race track system for 1/24 to 1/32 scale RC cars.
  *
- * A wavy flag to clip onto the barrier holders.
+ * A print plate presenting a set of straight unibody barriers with a double length.
  *
  * @author jsconan
  */
 
 // Import the project's setup.
-include <../../config/setup.scad>
+include <../../../config/setup.scad>
+
+use <../../../parts/unibody/straight/straight-double.scad>
 
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    accessoryFlag(
-        width = flagWidth,
-        height = flagHeight,
-        thickness = flagThickness,
-        mast = mastWidth,
-        wave = 2
-    );
+    centerBuildPlate() {
+        repeat(
+            count = 6,
+            intervalY = finalDoubleStraightBarrierUnibodyIntervalY(),
+            center = true
+        ) {
+            finalDoubleStraightBarrierUnibody();
+        }
+    }
 }

--- a/rcmodels/tracks/plates/unibody/straight/straight-simple.scad
+++ b/rcmodels/tracks/plates/unibody/straight/straight-simple.scad
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * GPLv3 License
+ *
+ * Copyright (c) 2020 Jean-Sebastien CONAN
+ *
+ * This file is part of jsconan/things.
+ *
+ * jsconan/things is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * jsconan/things is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with jsconan/things. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A race track system for 1/24 to 1/32 scale RC cars.
+ *
+ * A print plate presenting a set of straight unibody barriers with a simple length.
+ *
+ * @author jsconan
+ */
+
+// Import the project's setup.
+include <../../../config/setup.scad>
+use <../../../parts/unibody/straight/straight-simple.scad>
+
+// Sets the minimum facet angle and size using the defined render mode.
+applyMode(mode=renderMode) {
+    // Uncomment the next line to cut a sample from the object
+    //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
+    centerBuildPlate() {
+        repeat(
+            count = 10,
+            intervalY = finalSimpleStraightBarrierUnibodyIntervalY(),
+            center = true
+        ) {
+            finalSimpleStraightBarrierUnibody();
+        }
+    }
+}

--- a/rcmodels/tracks/plates/unibody/straight/straight-uturn.scad
+++ b/rcmodels/tracks/plates/unibody/straight/straight-uturn.scad
@@ -23,21 +23,28 @@
 /**
  * A race track system for 1/24 to 1/32 scale RC cars.
  *
- * A sample for a straight track part, 5x the length.
+ * A print plate presenting a set of straight unibody barriers to compensate a U-turn track part.
  *
  * @author jsconan
  */
 
 // Import the project's setup.
 include <../../../config/setup.scad>
+use <../../../parts/unibody/straight/straight-uturn.scad>
 
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=renderMode) {
     // Uncomment the next line to cut a sample from the object
     //sample(size=[DEFAULT_BUILD_PLATE_SIZE, DEFAULT_BUILD_PLATE_SIZE, 5], offset=[0, 0, 0])
-    straightBarrierMain(
-        length = sampleSize * 10,
-        thickness = barrierBodyThickness,
-        base = sampleBase
-    );
+    centerBuildPlate() {
+        repeat2D(
+            countX = 2,
+            countY = 5,
+            intervalX = [finalUTurnCompensationBarrierUnibodyIntervalX(), 0, 0],
+            intervalY = [0, finalUTurnCompensationBarrierUnibodyIntervalY(), 0],
+            center = true
+        ) {
+            finalUTurnCompensationBarrierUnibody();
+        }
+    }
 }

--- a/rcmodels/tracks/shapes/accessories.scad
+++ b/rcmodels/tracks/shapes/accessories.scad
@@ -23,10 +23,105 @@
 /**
  * A race track system for 1/24 to 1/32 scale RC cars.
  *
- * Defines the shapes for the track  accessories.
+ * Defines the shapes for the track accessories.
  *
  * @author jsconan
  */
+
+/**
+ * Gets the approximated length of the shape of a cable clip.
+ * @param Number wall - The thickness of the cable clip lines.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @returns Number
+ */
+function getCableClipLength(wall, base) =
+    getBarrierHolderWidth(base, wall)
+;
+
+/**
+ * Gets the approximated width of the shape of a cable clip.
+ * @param Number wall - The thickness of the cable clip lines.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @returns Number
+ */
+function getCableClipWidth(wall, base) =
+    getBarrierHolderHeight(base, wall) +
+    apothem(n=10, r=getCableClipLength(wall, base) / 2)
+;
+
+/**
+ * Gets the approximated length of the shape of a bent accessory mast.
+ * @param Number width - The width of the mast.
+ * @param Number|Vector height - The height of the mast. The 2 sides can be defined separately using a vector.
+ * @param Number wall - The thickness of the accessory clip lines.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @returns Number
+ */
+function getAccessoryBentMastLength(width, height, wall, base) =
+    let(
+        height = vector2D(height)
+    )
+    getBarrierHolderWidth(base, wall) / 2 +
+    width + height[1]
+;
+
+/**
+ * Gets the approximated width of the shape of a bent accessory mast.
+ * @param Number width - The width of the mast.
+ * @param Number|Vector height - The height of the mast. The 2 sides can be defined separately using a vector.
+ * @param Number wall - The thickness of the accessory clip lines.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @returns Number
+ */
+function getAccessoryBentMastWidth(width, height, wall, base) =
+    let(
+        height = vector2D(height)
+    )
+    getBarrierHolderHeight(base, wall) +
+    width * 1.5 + height[0]
+;
+
+/**
+ * Gets the approximated length of the shape of an accessory mast.
+ * @param Number height - The height of the mast.
+ * @param Number wall - The thickness of the accessory clip lines.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @returns Number
+ */
+function getAccessoryStraightMastLength(height, wall, base) =
+    getBarrierHolderHeight(base, wall) + height
+;
+
+/**
+ * Gets the approximated width of the shape of an accessory mast.
+ * @param Number wall - The thickness of the accessory clip lines.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @returns Number
+ */
+function getAccessoryStraightMastWidth(wall, base) =
+    getBarrierHolderWidth(base, wall)
+;
+
+/**
+ * Gets the approximated length of the shape of an accessory flag.
+ * @param Number width - The width of the flag.
+ * @param Number thickness - The thickness of the flag.
+ * @param Number mast - The width of the mast.
+ * @returns Number
+ */
+function getAccessoryFlagLength(width, thickness, mast) =
+    width + mast / 2 + printResolution + thickness
+;
+
+/**
+ * Gets the approximated length of the shape of an accessory flag.
+ * @param Number height - The height of the flag.
+ * @param Number wave - The height of the wave
+ * @returns Number
+ */
+function getAccessoryFlagWidth(height, wave = 0) =
+    height + wave * 2
+;
 
 /**
  * Draws the shape of a cable clip.
@@ -37,26 +132,42 @@
  * @param Boolean [center] - The shape is centered vertically.
  */
 module cableClip(height, wall, base, thickness, center = false) {
-    holderWidth = getBarrierHolderWidth(base) + (wall + printTolerance) * 2;
-    negativeExtrude(height=height, center=center) {
-        clipProfile(
-            wall = wall,
-            base = base,
-            thickness = thickness + printTolerance,
-            distance = printTolerance
-        );
-        repeat(intervalX = holderWidth - wall, center = true) {
-            translateY(base / 2) {
-                rectangle([wall, base]);
+    clipWidth = getCableClipLength(wall, base);
+
+    translateY((apothem(n=10, r=clipWidth) - getCableClipWidth(wall, base)) / 2) {
+        linear_extrude(height=height, center=center, convexity=10) {
+            clipProfile(
+                wall = wall,
+                base = base,
+                thickness = thickness + printTolerance
+            );
+            repeat(intervalX = clipWidth - wall, center = true) {
+                translateY(base / 2) {
+                    rectangle([wall, base]);
+                }
             }
+            ringSegment(
+                r = [1, 1] * (clipWidth / 2),
+                w = wall,
+                a = -180,
+                $fn = 10
+            );
         }
-        ringSegment(
-            r = [1, 1] * (holderWidth / 2),
-            w = wall,
-            a = -180,
-            $fn = 10
-        );
     }
+}
+
+/**
+ * Draws the profile shape of an accessory mast.
+ * @param Number width - The width of the mast.
+ * @param Number [distance] - An additional distance added to the outline.
+ */
+module mastProfile(width, distance = 0) {
+    radius = getMastRadius(width);
+
+    polygon(
+        points = outline(drawEllipse(r=radius, $fn=mastFacets), distance),
+        convexity = 10
+    );
 }
 
 /**
@@ -67,14 +178,53 @@ module cableClip(height, wall, base, thickness, center = false) {
  * @param Boolean [center] - The shape is centered vertically.
  */
 module mast(width, height, distance = 0, center = false) {
-    radius = getMastRadius(width);
-
-    negativeExtrude(height=height, center=center) {
+    linear_extrude(height=height, center=center, convexity=10) {
         rotateZ(getPolygonAngle(1, mastFacets) / 2) {
-            polygon(
-                points = outline(drawEllipse(r=radius, $fn=mastFacets), distance),
-                convexity = 10
+            mastProfile(
+                width = width,
+                distance = distance
             );
+        }
+    }
+}
+
+/**
+ * Draws the shape of a bent accessory mast.
+ * @param Number width - The width of the mast.
+ * @param Number|Vector height - The height of the mast. The 2 sides can be defined separately using a vector.
+ * @param Number [distance] - An additional distance added to the outline.
+ */
+module bentMast(width, height, distance = 0) {
+    height = vector2D(height);
+
+    mast(
+        width = width,
+        height = height[0],
+        distance = distance,
+        center = false
+    );
+    translate([0, -width, height[0] + width]) {
+        rotateX(90) {
+            mast(
+                width = width,
+                height = height[1],
+                distance = distance,
+                center = false
+            );
+        }
+    }
+    translate([0, -width, height[0]]) {
+        rotate([90, 0, 90]) {
+            rotate_extrude(angle=90, convexity=10) {
+                translateX(width) {
+                    rotateZ(getPolygonAngle(1, mastFacets) / 2) {
+                        mastProfile(
+                            width = width,
+                            distance = distance
+                        );
+                    }
+                }
+            }
         }
     }
 }
@@ -118,22 +268,62 @@ module mastRings(width, height, wall, interval = 0, count = 1, distance = 0, cen
  * @param Number base - The base unit value used to design the barrier holder.
  * @param Number thickness - The thickness of the barrier body.
  */
-module accessoryMast(width, height, wall, base, thickness) {
-    rotateY(90) {
-        mast(
-            width = width,
-            height = height,
-            distance = 0,
-            center = false
-        );
+module accessoryStraightMast(width, height, wall, base, thickness) {
+    clipHeight = getBarrierHolderHeight(base, wall);
+
+    translateX((clipHeight - height) / 2) {
+        rotateY(90) {
+            mast(
+                width = width,
+                height = height,
+                distance = 0,
+                center = false
+            );
+        }
+        rotateZ(90) {
+            clip(
+                wall = wall,
+                height = width,
+                base = base,
+                thickness = thickness + printTolerance,
+                center = true
+            );
+        }
     }
-    rotateZ(90) {
+}
+
+/**
+ * Draws the shape of a bent accessory mast with a clip.
+ * @param Number width - The width of the mast.
+ * @param Number|Vector height - The height of the mast. The 2 sides can be defined separately using a vector.
+ * @param Number wall - The thickness of the accessory clip lines.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number thickness - The thickness of the barrier body.
+ */
+module accessoryBentMast(width, height, wall, base, thickness) {
+    height = vector2D(height);
+    clipWidth = getBarrierHolderWidth(base, wall);
+    clipHeight = getBarrierHolderHeight(base, wall);
+    bentMastLength = getAccessoryBentMastLength(width, height, wall, base);
+    bentMastWidth = getAccessoryBentMastWidth(width, height, wall, base);
+
+    translate([
+        (clipWidth - bentMastLength) / 2,
+        bentMastWidth / 2 - clipHeight,
+        0
+    ]) {
+        rotate([0, 270, 90]) {
+            bentMast(
+                width = width,
+                height = height,
+                distance = 0
+            );
+        }
         clip(
             wall = wall,
             height = width,
             base = base,
             thickness = thickness + printTolerance,
-            distance = printTolerance,
             center = true
         );
     }
@@ -154,23 +344,27 @@ module accessoryFlag(width, height, thickness, mast, wave = 0) {
     ringOffset = apothem(n=mastFacets, r=getMastRadius(mast)) + distance + thickness;
     type = wave ? "S" : "V";
 
-    translateZ(ringOffset) {
-        mastRings(
-            width = mast,
-            height = ringHeight,
-            wall = thickness,
-            interval = ringInterval,
-            count = 2,
-            distance = distance,
-            center = true
-        );
-    }
-    negativeExtrude(thickness) {
-        polygon(path([
-            ["P", height / 2, 0],
-            [type, width, width, wave, 0, 90],
-            ["H", -height],
-            [type, -width, width, wave, 0, 90]
-        ]));
+    rotateZ(270) {
+        translateY((mast - width) / 2 - printResolution) {
+            translateZ(ringOffset) {
+                mastRings(
+                    width = mast,
+                    height = ringHeight,
+                    wall = thickness,
+                    interval = ringInterval,
+                    count = 2,
+                    distance = distance,
+                    center = true
+                );
+            }
+            linear_extrude(height=thickness, convexity=10) {
+                polygon(path([
+                    ["P", height / 2, 0],
+                    [type, width, width, wave, 0, 90],
+                    ["H", -height],
+                    [type, -width, width, wave, 0, 90]
+                ]));
+            }
+        }
     }
 }

--- a/rcmodels/tracks/shapes/fragments.scad
+++ b/rcmodels/tracks/shapes/fragments.scad
@@ -36,7 +36,7 @@
  * @param Boolean [center] - The shape is centered vertically.
  */
 module barrierLink(height, base, distance = 0, center = false) {
-    negativeExtrude(height=height, center=center) {
+    linear_extrude(height=height, center=center, convexity=10) {
         barrierLinkProfile(
             base = base,
             distance = distance
@@ -55,7 +55,7 @@ module barrierLink(height, base, distance = 0, center = false) {
  */
 module barrierNotch(thickness, base, distance = 0, interval = 0, count = 1, center = false) {
     repeat(count=count, interval=[interval, 0, 0], center=true) {
-        negativeExtrude(height=thickness, center=center) {
+        linear_extrude(height=thickness, center=center, convexity=10) {
             barrierNotchProfile(
                 base = base,
                 distance = distance
@@ -124,7 +124,7 @@ module carveBarrierNotch(length, thickness, base, notches = 2) {
  * @param Boolean [center] - The shape is centered vertically.
  */
 module clip(wall, height, base, thickness, distance = 0, center = false) {
-    negativeExtrude(height=height, center=center) {
+    linear_extrude(height=height, center=center, convexity=10) {
         clipProfile(
             wall = wall,
             base = base,

--- a/rcmodels/tracks/shapes/profiles.scad
+++ b/rcmodels/tracks/shapes/profiles.scad
@@ -54,9 +54,8 @@ module barrierLinkProfile(base, distance = 0) {
 module barrierNotchProfile(base, distance = 0) {
     width = getBarrierNotchWidth(base, distance);
     top = getBarrierNotchDistance(base, distance);
-    strip = getBarrierStripHeight(base);
     indent = getBarrierStripIndent(base);
-    height = strip - indent;
+    height = getBarrierStripHeight(base) - indent;
 
     polygon(path([
         ["P", -width / 2, 0],
@@ -69,32 +68,47 @@ module barrierNotchProfile(base, distance = 0) {
 }
 
 /**
+ * Draws the outline of a barrier holder profile.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number holderOffset - The offset of the shape edges.
+ * @param Number bottomWidth - The width of the bottom of the shape.
+ * @param Number topWidth - The width of the top of the shape.
+ * @returns Vector[]
+ */
+function getBarrierHolderProfilePoints(base, holderOffset, bottomWidth, topWidth) =
+    let(
+        holderHeight = getBarrierHolderHeight(base),
+        holderSide = base - holderOffset,
+        holderLineX = (bottomWidth - topWidth) / 2 - holderOffset,
+        holderLineY = holderHeight - holderSide - holderOffset * 2
+    )
+    path([
+        ["P", holderOffset - bottomWidth / 2, 0],
+        ["L", -holderOffset, holderOffset],
+        ["V", holderSide],
+        ["L", holderLineX, holderLineY],
+        ["L", holderOffset, holderOffset],
+        ["H", topWidth],
+        ["L", holderOffset, -holderOffset],
+        ["L", holderLineX, -holderLineY],
+        ["V", -holderSide],
+        ["L", -holderOffset, -holderOffset]
+    ])
+;
+
+/**
  * Draws the profile of a barrier holder.
  * @param Number base - The base unit value used to design the barrier holder.
  * @param Number thickness - The thickness of the barrier body.
  * @param Number [distance] - An additional distance added to the outline of the profile.
  */
 module barrierHolderProfile(base, thickness, distance = 0) {
-    holderTopWidth = getBarrierHolderTopWidth(base, thickness);
-    holderWidth = getBarrierHolderWidth(base);
-    holderHeight = getBarrierHolderHeight(base);
-    holderOffset = base / 4;
-    holderSide = base - holderOffset;
-    holderLineX = (holderWidth - holderTopWidth) / 2 - holderOffset;
-    holderLineY = holderHeight - holderSide - holderOffset * 2;
-
-    polygon(outline(path([
-        ["P", holderOffset - holderWidth / 2, 0],
-        ["L", -holderOffset, holderOffset],
-        ["V", holderSide],
-        ["L", holderLineX, holderLineY],
-        ["L", holderOffset, holderOffset],
-        ["H", holderTopWidth],
-        ["L", holderOffset, -holderOffset],
-        ["L", holderLineX, -holderLineY],
-        ["V", -holderSide],
-        ["L", -holderOffset, -holderOffset]
-    ]), -distance), convexity = 10);
+    polygon(outline(getBarrierHolderProfilePoints(
+        base = base,
+        holderOffset = base / 4,
+        bottomWidth = getBarrierHolderWidth(base),
+        topWidth = getBarrierHolderTopWidth(base, thickness)
+    ), -distance), convexity = 10);
 }
 
 /**
@@ -114,14 +128,16 @@ module barrierUnibodyProfile(height, base, thickness, distance = 0) {
     holderLineX = (holderWidth - holderTopWidth) / 2 - holderOffset;
     holderLineY = holderHeight - base - holderOffset;
 
+    unibodyOffset = base / 2;
     unibodyNeck = base / 2;
+    unibodySide = base - unibodyOffset;
     unibodyWidth = getBarrierUnibodyWidth(base);
-    unibodyOffsetWidth = unibodyWidth - holderOffset * 2;
-    unibodyLineX = (unibodyWidth - holderTopWidth) / 2 - holderOffset;
-    unibodyLineY = height - holderHeight - unibodyNeck - base - holderOffset;
+    unibodyOffsetWidth = unibodyWidth - unibodyOffset * 2;
+    unibodyLineX = (unibodyWidth - holderTopWidth) / 2 - unibodyOffset;
+    unibodyLineY = height - holderHeight - unibodyNeck - base - unibodyOffset;
 
     startX = holderTopWidth / 2;
-    startY = holderSide + unibodyLineY + unibodyNeck + holderOffset * 2;
+    startY = holderSide + unibodyLineY + unibodyOffset + unibodyNeck + holderOffset;
 
     polygon(outline(path([
         ["P", -startX, startY],
@@ -137,15 +153,15 @@ module barrierUnibodyProfile(height, base, thickness, distance = 0) {
         ["L", -holderOffset, -holderOffset],
         // unibody profile
         ["V", -unibodyNeck],
-        ["L", holderOffset, -holderOffset],
+        ["L", unibodyOffset, -unibodyOffset],
         ["L", unibodyLineX, -unibodyLineY],
-        ["V", -holderSide],
-        ["L", -holderOffset, -holderOffset],
+        ["V", -unibodySide],
+        ["L", -unibodyOffset, -unibodyOffset],
         ["H", -unibodyOffsetWidth],
-        ["L", -holderOffset, holderOffset],
-        ["V", holderSide],
+        ["L", -unibodyOffset, unibodyOffset],
+        ["V", unibodySide],
         ["L", unibodyLineX, unibodyLineY],
-        ["L", holderOffset, holderOffset],
+        ["L", unibodyOffset, unibodyOffset],
         ["V", unibodyNeck]
     ]), -distance), convexity = 10);
 }

--- a/rcmodels/tracks/shapes/special.scad
+++ b/rcmodels/tracks/shapes/special.scad
@@ -29,26 +29,78 @@
  */
 
 /**
- * Draws the shape of a clip that will clamp a barrier border.
+ * Gets the length of an arch tower.
+ * @param Number length - The length of a track element.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number wall - The thickness of the clip outline.
+ * @returns Number
+ */
+function getArchTowerLength(length, base, wall) =
+    getBarrierHolderHeight(base, wall + printTolerance) +
+    length / 2
+;
+
+/**
+ * Gets the length of an arch tower with a male connector.
+ * @param Number length - The length of a track element.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number wall - The thickness of the clip outline.
+ * @returns Number
+ */
+function getArchTowerLengthMale(length, base, wall) =
+    getArchTowerLength(
+        length = length,
+        base = base,
+        wall = wall
+    ) + getBarrierLinkLength(base)
+;
+
+/**
+ * Gets the width of an arch tower.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number wall - The thickness of the clip outline.
+ * @returns Number
+ */
+function getArchTowerWidth(base, wall) =
+    getBarrierHolderWidth(base, wall + printTolerance)
+;
+
+/**
+ * Draws the shape of an arch tower that will clamp a barrier border.
  * @param Number thickness - The thickness of the barrier body.
  * @param Number base - The base unit value used to design the barrier holder.
  * @param Number wall - The thickness of the outline.
  */
-module archTowerClip(thickness, base, wall) {
+module archTower(length, thickness, base, wall) {
+    thickness = thickness + printTolerance;
     holderHeight = getBarrierHolderHeight(base);
-    indent = getBarrierStripIndent(base);
+    clipHeight = getBarrierHolderHeight(base, wall + printTolerance);
+    indent = getBarrierStripIndent(base) + printResolution;
+    length = length / 2;
 
-    rotateZ(-90) {
-        difference() {
-            clip(
-                wall = wall,
-                height = holderHeight,
-                base = base,
-                thickness = thickness,
-                distance = printTolerance
-            );
-            translate([0, wall / 2, holderHeight - indent]) {
-                box([thickness, wall * 2, indent * 2]);
+    translateX(-clipHeight / 2) {
+        translateX(length / 2) {
+            rotateZ(-90) {
+                difference() {
+                    clip(
+                        wall = wall,
+                        height = holderHeight,
+                        base = base,
+                        thickness = thickness,
+                        distance = printTolerance
+                    );
+                    translate([0, wall / 2, holderHeight - indent]) {
+                        box([thickness, wall * 2, indent * 2]);
+                    }
+                }
+            }
+        }
+        carveBarrierNotch(length=length, thickness=thickness, base=base, notches=1) {
+            extrudeStraightProfile(length=length) {
+                barrierHolderProfile(
+                    base = base,
+                    thickness = thickness
+                );
             }
         }
     }
@@ -62,28 +114,20 @@ module archTowerClip(thickness, base, wall) {
  * @param Number wall - The thickness of the outline.
  */
 module archTowerMale(length, thickness, base, wall) {
-    thickness = thickness + printTolerance;
-    holderHeight = getBarrierHolderHeight(base);
     linkHeight = getBarrierHolderLinkHeight(base);
-    indent = getBarrierStripIndent(base);
-    length = length / 2;
+    archTowerLength = getArchTowerLength(
+        length = length,
+        base = base,
+        wall = wall
+    );
 
-    translateX(length / 2) {
-        archTowerClip(
+    straightLinkMale(length=archTowerLength, linkHeight=linkHeight, base=base) {
+        archTower(
+            length = length,
             thickness = thickness,
             base = base,
             wall = wall
         );
-    }
-    carveBarrierNotch(length=length, thickness=thickness, base=base, notches=1) {
-        straightLinkMale(length=length, linkHeight=linkHeight, base=base) {
-            extrudeStraightProfile(length=length) {
-                barrierHolderProfile(
-                    base = base,
-                    thickness = thickness
-                );
-            }
-        }
     }
 }
 
@@ -95,28 +139,188 @@ module archTowerMale(length, thickness, base, wall) {
  * @param Number wall - The thickness of the outline.
  */
 module archTowerFemale(length, thickness, base, wall) {
-    thickness = thickness + printTolerance;
-    holderHeight = getBarrierHolderHeight(base);
     linkHeight = getBarrierHolderLinkHeight(base);
-    indent = getBarrierStripIndent(base);
+    archTowerLength = getArchTowerLength(
+        length = length,
+        base = base,
+        wall = wall
+    );
+
+    rotateZ(180) {
+        straightLinkFemale(length=archTowerLength, linkHeight=linkHeight, base=base) {
+            rotateZ(180) {
+                archTower(
+                    length = length,
+                    thickness = thickness,
+                    base = base,
+                    wall = wall
+                );
+            }
+        }
+    }
+}
+
+/**
+ * Draws the shape of a connector between a barrier holder and a unibody barrier.
+ * @param Number length - The length of a track element.
+ * @param Number height - The height of the barrier.
+ * @param Number thickness - The thickness of the barrier body.
+ * @param Number base - The base unit value used to design the barrier holder.
+ */
+module barrierHolderToUnibodyConnector(length, height, thickness, base) {
+    holderTopWidth = getBarrierHolderTopWidth(base, thickness);
+    holderWidth = getBarrierHolderWidth(base);
+    holderHeight = getBarrierHolderHeight(base);
+    holderLinkHeight = getBarrierHolderLinkHeight(base);
+    unibodyWidth = getBarrierUnibodyWidth(base);
+    unibodyLineX = (unibodyWidth - holderTopWidth) / 2 - base / 2;
+    unibodyLineY = height - holderHeight - base * 2;
+    holderLineY = holderHeight - base * 1.5;
+    unibodyTopWidth = unibodyWidth - base - holderLineY * (unibodyLineX / unibodyLineY) * 2;
+    indent = getBarrierStripIndent(base) + printResolution;
     length = length / 2;
 
-    translateX(length / 2) {
-        archTowerClip(
-            thickness = thickness,
-            base = base,
-            wall = wall
-        );
-    }
-    rotateZ(180) {
+    distribute(intervalX=length, center=true) {
+        difference() {
+            extrudeStraightProfile(length=length) {
+                barrierUnibodyProfile(
+                    height = height,
+                    base = base,
+                    thickness = thickness
+                );
+            }
+            translate([length / 2, 0, height - holderLinkHeight]) {
+                barrierLink(
+                    height = holderLinkHeight + printResolution + 1,
+                    base = base,
+                    distance = printTolerance
+                );
+            }
+            translate([length / 2, 0, holderHeight - indent]) {
+                box([thickness, thickness, indent]);
+            }
+        }
         carveBarrierNotch(length=length, thickness=thickness, base=base, notches=1) {
-            straightLinkFemale(length=length, linkHeight=linkHeight, base=base) {
-                extrudeStraightProfile(length=length) {
-                    barrierHolderProfile(
-                        base = base,
-                        thickness = thickness
-                    );
+            translateX(-length / 2) {
+                rotate([90, 0, 90]) {
+                    repeatMirror() {
+                        simplePolyhedron(
+                            bottom = reverse(getBarrierHolderProfilePoints(
+                                base = base,
+                                holderOffset = base / 2,
+                                bottomWidth = unibodyWidth,
+                                topWidth = unibodyTopWidth
+                            )),
+                            top = reverse(getBarrierHolderProfilePoints(
+                                base = base,
+                                holderOffset = base / 4,
+                                bottomWidth = holderWidth,
+                                topWidth = holderTopWidth
+                            )),
+                            z = length
+                        );
+                    }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Draws the shape of a male connector between a barrier holder and a unibody barrier.
+ * @param Number length - The length of a track element.
+ * @param Number height - The height of the barrier.
+ * @param Number thickness - The thickness of the barrier body.
+ * @param Number base - The base unit value used to design the barrier holder.
+ */
+module barrierHolderToUnibodyMale(length, height, thickness, base) {
+    thickness = thickness + printTolerance;
+    holderLinkHeight = getBarrierHolderLinkHeight(base);
+    unibodyLinkHeight = getBarrierUnibodyLinkHeight(height, base);
+
+    straightLinkMale(length=length, linkHeight=unibodyLinkHeight, base=base) {
+        straightLinkFemale(length=length, linkHeight=holderLinkHeight, base=base) {
+            barrierHolderToUnibodyConnector(
+                length = length,
+                height = height,
+                thickness = thickness,
+                base = base
+            );
+        }
+    }
+}
+
+/**
+ * Draws the shape of a female connector between a barrier holder and a unibody barrier.
+ * @param Number length - The length of a track element.
+ * @param Number height - The height of the barrier.
+ * @param Number thickness - The thickness of the barrier body.
+ * @param Number base - The base unit value used to design the barrier holder.
+ */
+module barrierHolderToUnibodyFemale(length, height, thickness, base) {
+    thickness = thickness + printTolerance;
+    holderLinkHeight = getBarrierHolderLinkHeight(base);
+    unibodyLinkHeight = getBarrierUnibodyLinkHeight(height, base);
+
+    straightLinkFemale(length=length, linkHeight=unibodyLinkHeight, base=base) {
+        straightLinkMale(length=length, linkHeight=holderLinkHeight, base=base) {
+            rotateZ(180) {
+                barrierHolderToUnibodyConnector(
+                    length = length,
+                    height = height,
+                    thickness = thickness,
+                    base = base
+                );
+            }
+        }
+    }
+}
+
+/**
+ * Draws the shape of a male connector for a barrier holder.
+ * @param Number length - The length of a track element.
+ * @param Number thickness - The thickness of the barrier body.
+ * @param Number base - The base unit value used to design the barrier holder.
+ */
+module barrierHolderConnectorMale(length, thickness, base) {
+    thickness = thickness + printTolerance;
+    linkHeight = getBarrierHolderLinkHeight(base);
+    length = length / 2;
+
+    carveBarrierNotch(length=length, thickness=thickness, base=base, notches=1) {
+        straightLinkMale(length=length, linkHeight=linkHeight, base=base) {
+            rotateZ(180) {
+                straightLinkMale(length=length, linkHeight=linkHeight, base=base) {
+                    extrudeStraightProfile(length=length) {
+                        barrierHolderProfile(
+                            base = base,
+                            thickness = thickness
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Draws the shape of a female connector for a barrier holder.
+ * @param Number length - The length of a track element.
+ * @param Number thickness - The thickness of the barrier body.
+ * @param Number base - The base unit value used to design the barrier holder.
+ */
+module barrierHolderConnectorFemale(length, thickness, base) {
+    thickness = thickness + printTolerance;
+    linkHeight = getBarrierHolderLinkHeight(base);
+    length = length / 2;
+
+    carveBarrierNotch(length=length, thickness=thickness, base=base, notches=1) {
+        straightLinks(length=length, linkHeight=linkHeight, base=base) {
+            extrudeStraightProfile(length=length) {
+                barrierHolderProfile(
+                    base = base,
+                    thickness = thickness
+                );
             }
         }
     }

--- a/rcmodels/tracks/shapes/straight.scad
+++ b/rcmodels/tracks/shapes/straight.scad
@@ -29,6 +29,17 @@
  */
 
 /**
+ * Gets the approximated length of the shape of a straight barrier.
+ * @param Number length - The length of the element.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number ratio - The ratio to apply on the length
+ * @returns Number
+ */
+function getStraightBarrierLength(length, base, ratio) =
+    length * ratio + getBarrierLinkLength(base)
+;
+
+/**
  * Draws the shape of a barrier body.
  * @param Number length - The length of the track element.
  * @param Number height - The height of the barrier.
@@ -113,7 +124,7 @@ module straightLinks(length, linkHeight, base) {
  */
 module extrudeStraightProfile(length) {
     rotate([90, 0, 90]) {
-        negativeExtrude(height=length, center=true) {
+        linear_extrude(height=length, center=true, convexity=10) {
             children();
         }
     }

--- a/rcmodels/tracks/shapes/uturn.scad
+++ b/rcmodels/tracks/shapes/uturn.scad
@@ -29,26 +29,68 @@
  */
 
 /**
+ * Gets the length of the final shape for a U-turn curve.
+ * @param Number length - The length of a track element.
+ * @param Number width - The width of a track element.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number gap - The distance between the two side of the U-turn.
+ * @returns Number
+ */
+function getUTurnBarrierLength(length, width, base, gap) =
+    getStraightBarrierLength(length, base, .5) + width + gap / 2
+;
+
+/**
+ * Gets the width of the final shape for a U-turn curve.
+ * @param Number width - The width of a track element.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number gap - The distance between the two side of the U-turn.
+ * @returns Number
+ */
+function getUTurnBarrierWidth(width, base, gap) = gap + width * 2;
+
+/**
+ * Gets the length of a U-turn compensation barrier.
+ * @param Number width - The width of a track element.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number gap - The distance between the two side of the U-turn.
+ * @returns Number
+ */
+function getUTurnCompensationBarrierLength(width, base, gap) =
+    width + gap + getBarrierLinkLength(base)
+;
+
+/**
+ * Gets the length of a U-turn compensation barrier body.
+ * @param Number length - The length of a track element.
+ * @param Number base - The base unit value used to design the barrier holder.
+ * @param Number gap - The distance between the two side of the U-turn.
+ * @returns Number
+ */
+function getUTurnCompensationBarrierBodyLength(length, base, gap) =
+    length + getBarrierHolderWidth(base) + gap
+;
+
+/**
  * Draws the shape of a barrier border for a U-Turn.
  * @param Number length - The length of a track element.
  * @param Number height - The height of the barrier.
  * @param Number thickness - The thickness of the barrier body.
  * @param Number base - The base unit value used to design the barrier holder.
- * @param Number gap - The distance between the two side of the u-turn.
+ * @param Number gap - The distance between the two side of the U-turn.
  * @param Number right - Is it the right or the left part of the track element that is added first?
  */
 module uTurnBarrierHolder(length, height, thickness, base, gap, right = false) {
     thickness = thickness + printTolerance;
-    holderWidth = getBarrierHolderWidth(base);
     holderHeight = getBarrierHolderHeight(base);
     linkHeight = getBarrierHolderLinkHeight(base);
     towerWidth = nozzleAligned(thickness + minWidth);
     towerHeight = getBarrierBodyInnerHeight(height, base) / 2;
-    interval = (holderWidth + gap) / 2;
+    interval = (getBarrierHolderWidth(base) + gap) / 2;
     dir = right ? -1 : 1;
     length = length / 2;
 
-    translateY(interval * dir) {
+    translate([-interval, interval * dir, 0]) {
         carveBarrierNotch(length=length, thickness=thickness, base=base, notches=1) {
             straightLinkMale(length=length, linkHeight=linkHeight, base=base) {
                 extrudeStraightProfile(length=length) {
@@ -60,7 +102,7 @@ module uTurnBarrierHolder(length, height, thickness, base, gap, right = false) {
             }
         }
     }
-    translateY(-interval * dir) {
+    translate([-interval, -interval * dir, 0]) {
         rotateZ(180) {
             carveBarrierNotch(length=length, thickness=thickness, base=base, notches=1) {
                 straightLinkFemale(length=length, linkHeight=linkHeight, base=base) {
@@ -74,7 +116,7 @@ module uTurnBarrierHolder(length, height, thickness, base, gap, right = false) {
             }
         }
     }
-    translateX(length / 2) {
+    translateX(length / 2 - interval) {
         rotateZ(270) {
             extrudeCurvedProfile(radius=interval, angle=180) {
                 barrierHolderProfile(
@@ -95,7 +137,7 @@ module uTurnBarrierHolder(length, height, thickness, base, gap, right = false) {
  * @param Number height - The height of the barrier.
  * @param Number thickness - The thickness of the barrier body for a barrier holder.
  * @param Number base - The base unit value used to design the barrier holder.
- * @param Number gap - The distance between the two side of the u-turn.
+ * @param Number gap - The distance between the two side of the U-turn.
  * @param Number right - Is it the right or the left part of the track element that is added first?
  */
 module uTurnBarrierUnibody(length, height, thickness, base, gap, right = false) {
@@ -105,7 +147,7 @@ module uTurnBarrierUnibody(length, height, thickness, base, gap, right = false) 
     dir = right ? -1 : 1;
     length = length / 2;
 
-    translateY(interval * dir) {
+    translate([-interval, interval * dir, 0]) {
         straightLinkMale(length=length, linkHeight=linkHeight, base=base) {
             extrudeStraightProfile(length=length) {
                 barrierUnibodyProfile(
@@ -116,7 +158,7 @@ module uTurnBarrierUnibody(length, height, thickness, base, gap, right = false) 
             }
         }
     }
-    translateY(-interval * dir) {
+    translate([-interval, -interval * dir, 0]) {
         rotateZ(180) {
             straightLinkFemale(length=length, linkHeight=linkHeight, base=base) {
                 extrudeStraightProfile(length=length) {
@@ -129,7 +171,7 @@ module uTurnBarrierUnibody(length, height, thickness, base, gap, right = false) 
             }
         }
     }
-    translateX(length / 2) {
+    translateX(length / 2 - interval) {
         rotateZ(270) {
             extrudeCurvedProfile(radius=interval, angle=180) {
                 barrierUnibodyProfile(
@@ -146,14 +188,12 @@ module uTurnBarrierUnibody(length, height, thickness, base, gap, right = false) 
  * Draws the shape of a barrier border for a U-Turn.
  * @param Number thickness - The thickness of the barrier body.
  * @param Number base - The base unit value used to design the barrier holder.
- * @param Number gap - The distance between the two side of the u-turn.
+ * @param Number gap - The distance between the two side of the U-turn.
  */
 module uTurnCompensationBarrierHolder(thickness, base, gap) {
-    holderWidth = getBarrierHolderWidth(base);
-    holderHeight = getBarrierHolderHeight(base);
-    length = holderWidth + gap;
+    length = getBarrierHolderWidth(base) + gap;
     indent = getBarrierStripIndent(base);
-    height = holderHeight - indent;
+    height = getBarrierHolderHeight(base) - indent;
     thickness = thickness + printTolerance;
 
     difference() {
@@ -173,10 +213,10 @@ module uTurnCompensationBarrierHolder(thickness, base, gap) {
  * @param Number height - The height of the barrier.
  * @param Number thickness - The thickness of the barrier body.
  * @param Number base - The base unit value used to design the barrier holder.
- * @param Number gap - The distance between the two side of the u-turn.
+ * @param Number gap - The distance between the two side of the U-turn.
  */
 module uTurnCompensationBarrierUnibody(height, thickness, base, gap) {
-    length = getBarrierHolderWidth(base) + gap;
+    length = getBarrierUnibodyWidth(base) + gap;
 
     straightBarrierUnibody(
         length = length,
@@ -187,19 +227,16 @@ module uTurnCompensationBarrierUnibody(height, thickness, base, gap) {
 }
 
 /**
- * Draws the shape of a barrier body.
+ * Draws the shape of a body for a U-turn compensation barrier.
  * @param Number length - The length of the track element.
  * @param Number height - The height of the barrier.
  * @param Number thickness - The thickness of the barrier body.
  * @param Number base - The base unit value used to design the barrier holder.
- * @param Number gap - The distance between the two side of the u-turn.
+ * @param Number gap - The distance between the two side of the U-turn.
  */
 module uTurnCompensationBarrierBody(length, height, thickness, base, gap) {
-    holderWidth = getBarrierHolderWidth(base);
-    strip = getBarrierStripHeight(base);
-    indent = getBarrierStripIndent(base);
-    stripHeight = strip - indent;
-    compensation = holderWidth + gap;
+    stripHeight = getBarrierStripHeight(base) - getBarrierStripIndent(base);
+    compensation = getBarrierHolderWidth(base) + gap;
     compensedLength = length + compensation;
     interval = length / 2;
 

--- a/rcmodels/tracks/test/accessories.scad
+++ b/rcmodels/tracks/test/accessories.scad
@@ -34,7 +34,7 @@ include <setup.scad>
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=mode) {
 
-    distributeGrid(intervalX=[length, 0, 0], intervalY=[0, height, 0], line=2, center=true) {
+    distributeGrid(intervalX=[length + printInterval, 0, 0], intervalY=[0, height, 0], line=2, center=true) {
 
         // test the cable clip shape
         cableClip(
@@ -51,6 +51,13 @@ applyMode(mode=mode) {
             distance = 0
         );
 
+        // test the accessory bent mast shape
+        bentMast(
+            width = base,
+            height = [base, height / 2],
+            distance = 0
+        );
+
         // test the accessory rings shape
         mastRings(
             width = base,
@@ -63,9 +70,18 @@ applyMode(mode=mode) {
         );
 
         // test the accessory clip shape
-        accessoryMast(
+        accessoryStraightMast(
             width = base,
             height = height,
+            wall = wall,
+            base = base,
+            thickness = thickness
+        );
+
+        // test the bent accessory clip shape
+        accessoryBentMast(
+            width = base,
+            height = [base, height / 2],
             wall = wall,
             base = base,
             thickness = thickness

--- a/rcmodels/tracks/test/curved.scad
+++ b/rcmodels/tracks/test/curved.scad
@@ -34,198 +34,68 @@ include <setup.scad>
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=mode) {
 
-    distribute(intervalX=length * 3, center=true) {
+    distributeGrid(
+        intervalX = [length * 2, 0, 0],
+        intervalY = [0, length * 2, 0],
+        line = 2, 
+        center = true
+    ) {
 
-        distribute(intervalY=length * 3, center=true) {
+        // test the main shape of a curved barrier holder, left turned
+        curvedBarrierMain(
+            length = length,
+            thickness = thickness,
+            base = base,
+            ratio = 1,
+            right = false
+        );
 
-            // test the main shape of a curved barrier holder, short curve, right turned
-            curvedBarrierMain(
-                length = length,
-                thickness = thickness,
-                base = base,
-                ratio = 0.5,
-                right = true
-            );
+        // test the main shape of a curved barrier holder, right turned
+        curvedBarrierMain(
+            length = length,
+            thickness = thickness,
+            base = base,
+            ratio = 1,
+            right = true
+        );
 
-            // test the main shape of a curved barrier holder, short curve, left turned
-            curvedBarrierMain(
-                length = length,
-                thickness = thickness,
-                base = base,
-                ratio = 0.5,
-                right = false
-            );
+        // test the shape of the curved barrier holder, left turned
+        curvedBarrierHolder(
+            length = length,
+            thickness = thickness,
+            base = base,
+            ratio = 1,
+            right = false
+        );
 
-            distributeRotate(center=true) {
+        // test the shape of the curved barrier holder, right turned
+        curvedBarrierHolder(
+            length = length,
+            thickness = thickness,
+            base = base,
+            ratio = 1,
+            right = true
+        );
 
-                // test the main shape of a curved barrier holder, inner curve, right turned
-                curvedBarrierMain(
-                    length = length,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getInnerCurveRatio(length, radius),
-                    right = true
-                );
+        // test the shape of a curved unibody barrier, left turned
+        curvedBarrierUnibody(
+            length = length,
+            height = height,
+            thickness = thickness,
+            base = base,
+            ratio = 1,
+            right = false
+        );
 
-                // test the main shape of a curved barrier holder, outer curve, right turned
-                curvedBarrierMain(
-                    length = length,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getOuterCurveRatio(length, width, radius),
-                    right = true
-                );
-
-                // test the main shape of a curved barrier holder, inner curve, left turned
-                curvedBarrierMain(
-                    length = length,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getInnerCurveRatio(length, radius),
-                    right = false
-                );
-
-                // test the main shape of a curved barrier holder, outer curve, left turned
-                curvedBarrierMain(
-                    length = length,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getOuterCurveRatio(length, width, radius),
-                    right = false
-                );
-
-            }
-        }
-
-        distribute(intervalY=length * 3, center=true) {
-
-            // test the shape of the curved barrier holder, short curve, right turned
-            curvedBarrierHolder(
-                length = length,
-                thickness = thickness,
-                base = base,
-                ratio = 0.5,
-                right = true
-            );
-
-            // test the shape of the curved barrier holder, short curve, left turned
-            curvedBarrierHolder(
-                length = length,
-                thickness = thickness,
-                base = base,
-                ratio = 0.5,
-                right = false
-            );
-
-            distributeRotate(center=true) {
-
-                // test the shape of the curved barrier holder, inner curve, right turned
-                curvedBarrierHolder(
-                    length = length,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getInnerCurveRatio(length, radius),
-                    right = true
-                );
-
-                // test the shape of the curved barrier holder, outer curve, right turned
-                curvedBarrierHolder(
-                    length = length,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getOuterCurveRatio(length, width, radius),
-                    right = true
-                );
-
-                // test the shape of the curved barrier holder, inner curve, left turned
-                curvedBarrierHolder(
-                    length = length,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getInnerCurveRatio(length, radius),
-                    right = false
-                );
-
-                // test the shape of the curved barrier holder, outer curve, left turned
-                curvedBarrierHolder(
-                    length = length,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getOuterCurveRatio(length, width, radius),
-                    right = false
-                );
-
-            }
-
-        }
-
-        distribute(intervalY=length * 3, center=true) {
-
-            // test the shape of a curved unibody barrier, short curve, right turned
-            curvedBarrierUnibody(
-                length = length,
-                height = height,
-                thickness = thickness,
-                base = base,
-                ratio = 0.5,
-                right = true
-            );
-
-            // test the shape of a curved unibody barrier, short curve, left turned
-            curvedBarrierUnibody(
-                length = length,
-                height = height,
-                thickness = thickness,
-                base = base,
-                ratio = 0.5,
-                right = false
-            );
-
-            distributeRotate(center=true) {
-
-                // test the shape of a curved unibody barrier, inner curve, right turned
-                curvedBarrierUnibody(
-                    length = length,
-                    height = height,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getInnerCurveRatio(length, radius),
-                    right = true
-                );
-
-                // test the shape of a curved unibody barrier, outer curve, right turned
-                curvedBarrierUnibody(
-                    length = length,
-                    height = height,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getOuterCurveRatio(length, width, radius),
-                    right = true
-                );
-
-                // test the shape of a curved unibody barrier, inner curve, left turned
-                curvedBarrierUnibody(
-                    length = length,
-                    height = height,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getInnerCurveRatio(length, radius),
-                    right = false
-                );
-
-                // test the shape of a curved unibody barrier, outer curve, left turned
-                curvedBarrierUnibody(
-                    length = length,
-                    height = height,
-                    thickness = thickness,
-                    base = base,
-                    ratio = getOuterCurveRatio(length, width, radius),
-                    right = false
-                );
-
-            }
-
-        }
+        // test the shape of a curved unibody barrier, right turned
+        curvedBarrierUnibody(
+            length = length,
+            height = height,
+            thickness = thickness,
+            base = base,
+            ratio = 1,
+            right = true
+        );
 
     }
 }

--- a/rcmodels/tracks/test/special.scad
+++ b/rcmodels/tracks/test/special.scad
@@ -34,13 +34,22 @@ include <setup.scad>
 // Sets the minimum facet angle and size using the defined render mode.
 applyMode(mode=mode) {
 
-    distributeGrid(intervalX=[length * 1.5, 0, 0], intervalY=[0, height * 1.5, 0], line=3, center=true) {
+    distributeGrid(intervalX=[length * 1.5, 0, 0], intervalY=[0, height * 1.5, 0], line=2, center=true) {
 
         // test the shape of an arch tower clip
-        archTowerClip(
+        archTower(
+            length = length,
             thickness = thickness,
             base = base,
             wall = wall * 2
+        );
+
+        // test the shape of a connector between a barrier holder and a unibody barrier
+        barrierHolderToUnibodyConnector(
+            length = length,
+            height = height,
+            thickness = thickness,
+            base = base
         );
 
         // test the shape of an arch tower, male version
@@ -57,6 +66,36 @@ applyMode(mode=mode) {
             thickness = thickness,
             base = base,
             wall = wall * 2
+        );
+
+        // test the shape of a connector between a barrier holder and a unibody barrier, male version
+        barrierHolderToUnibodyMale(
+            length = length,
+            height = height,
+            thickness = thickness,
+            base = base
+        );
+
+        // test the shape of a connector between a barrier holder and a unibody barrier, female version
+        barrierHolderToUnibodyFemale(
+            length = length,
+            height = height,
+            thickness = thickness,
+            base = base
+        );
+
+        // test the shape of the additional connector between a barrier holder and a unibody barrier, male version
+        barrierHolderConnectorMale(
+            length = length,
+            thickness = thickness,
+            base = base
+        );
+
+        // test the shape of the additional connector between a barrier holder and a unibody barrier, female version
+        barrierHolderConnectorFemale(
+            length = length,
+            thickness = thickness,
+            base = base
         );
 
     }

--- a/rcmodels/tracks/test/uturn.scad
+++ b/rcmodels/tracks/test/uturn.scad
@@ -36,7 +36,7 @@ applyMode(mode=mode) {
 
     distribute(intervalY=length, center=true) {
 
-        // test the u-turn holder shape, left side
+        // test the U-turn holder shape, left side
         uTurnBarrierHolder(
             length = length,
             height = height,
@@ -46,7 +46,7 @@ applyMode(mode=mode) {
             right = false
         );
 
-        // test the u-turn holder shape, right side
+        // test the U-turn holder shape, right side
         uTurnBarrierHolder(
             length = length,
             height = height,
@@ -56,7 +56,7 @@ applyMode(mode=mode) {
             right = true
         );
 
-        // test the u-turn unibody shape, left side
+        // test the U-turn unibody shape, left side
         uTurnBarrierUnibody(
             length = length,
             height = height,
@@ -66,7 +66,7 @@ applyMode(mode=mode) {
             right = false
         );
 
-        // test the u-turn unibody shape, right side
+        // test the U-turn unibody shape, right side
         uTurnBarrierUnibody(
             length = length,
             height = height,
@@ -76,7 +76,7 @@ applyMode(mode=mode) {
             right = true
         );
 
-        // test the u-turn compensation shape
+        // test the U-turn compensation shape
         uTurnCompensationBarrierUnibody(
             height = height,
             thickness = thickness,
@@ -84,14 +84,14 @@ applyMode(mode=mode) {
             gap = wall
         );
 
-        // test the u-turn compensation shape
+        // test the U-turn compensation shape
         uTurnCompensationBarrierHolder(
             thickness = thickness,
             base = base,
             gap = wall
         );
 
-        // test the u-turn compensation body shape
+        // test the U-turn compensation body shape
         uTurnCompensationBarrierBody(
             length = length,
             height = height,


### PR DESCRIPTION
Improved design of the race track system for 1/24 to 1/32 scale RC cars.
- Encapsulate the shapes into final modules
- Add sizing functions
- Add more printer constraints (size of the printer's plate)
- Add print plates for sets of elements
- The file structure has been updated.
- Add a special barrier connector to link barrier holders to unibody barriers (straight version only)
- The render script has been reworked, adding more options

---

Notes:
- Import from the repository [jsconan/things](https://github.com/jsconan/things)
- Extract of the pull request https://github.com/jsconan/things/pull/47
