### PR TITLE
Feature/Import from repo Things/Version 0.4.2

### DIFF
--- a/rcmodels/tracks/config/config.scad
+++ b/rcmodels/tracks/config/config.scad
@@ -28,7 +28,7 @@
  * @author jsconan
  */
 
- projectVersion = "0.4.1";
+ projectVersion = "0.4.2";
 
 // We will render the object using the specifications of this mode
 renderMode = MODE_PROD;

--- a/rcmodels/tracks/shapes/uturn.scad
+++ b/rcmodels/tracks/shapes/uturn.scad
@@ -245,17 +245,16 @@ module uTurnCompensationBarrierUnibody(height, thickness, base, gap) {
 module uTurnCompensationBarrierBody(length, height, thickness, base, gap) {
     stripHeight = getBarrierStripHeight(base) - getBarrierStripIndent(base);
     compensation = getBarrierHolderWidth(base) + gap;
-    compensedLength = length + compensation;
-    interval = length / 2;
+    interval = (length - compensation) / 2;
 
     difference() {
         box(
-            size = [compensedLength, height, thickness],
+            size = [length, height, thickness],
             center = true
         );
         repeatMirror(interval=[0, height, 0], axis=[0, 1, 0], center=true) {
             repeatMirror() {
-                translateX((compensedLength - interval) / 2) {
+                translateX((length - interval) / 2) {
                     barrierNotch(
                         thickness = thickness * 2,
                         base = base,


### PR DESCRIPTION
Fixed design of the race track system for 1/24 to 1/32 scale RC cars.
- Fix the length of the special barrier body related to a U-turn compensation barrier.

---

Notes:
- Import from the repository [jsconan/things](https://github.com/jsconan/things)
- Extract of the pull request https://github.com/jsconan/things/pull/49
