### PR TITLE
Fix/scale 24 render config

### DIFF
--- a/scale-24/render.sh
+++ b/scale-24/render.sh
@@ -59,6 +59,22 @@ slice=
 # include libs
 source "${scriptpath}/../lib/camelSCAD/scripts/utils.sh"
 
+# Builds the list of config parameters.
+# @param right - Right oriented or left oriented
+paramlist() {
+    local rightOriented=$1
+    local params=(
+        "$(varif "trackSectionLength" ${trackSectionLength})" \
+        "$(varif "trackSectionWidth" ${trackSectionWidth})" \
+        "$(varif "trackLaneWidth" ${trackLaneWidth})" \
+        "$(varif "trackRadius" ${trackRadius})" \
+        "$(varif "barrierHeight" ${barrierHeight})" \
+        "$(varif "sampleSize" ${sampleSize})" \
+        "$(varif "rightOriented" ${rightOriented})"
+    )
+    echo "${params[@]}"
+}
+
 # Renders the files from a path.
 #
 # @param sourcepath - The path of the folder containing the SCAD files to render.
@@ -67,15 +83,7 @@ source "${scriptpath}/../lib/camelSCAD/scripts/utils.sh"
 # @param prefix - Optional prefix added to the output fil name
 # @param suffix - Optional suffix added to the output fil name
 renderpath() {
-    local rightOriented=$3
-    scadrenderall "$1" "$2" "$4" "$5" --quiet \
-        "$(varif "trackSectionLength" ${trackSectionLength})" \
-        "$(varif "trackSectionWidth" ${trackSectionWidth})" \
-        "$(varif "trackLaneWidth" ${trackLaneWidth})" \
-        "$(varif "trackRadius" ${trackRadius})" \
-        "$(varif "barrierHeight" ${barrierHeight})" \
-        "$(varif "sampleSize" ${sampleSize})" \
-        "$(varif "rightOriented" ${rightOriented})"
+    scadrenderall "$1" "$2" "$4" "$5" --quiet $(paramlist $3)
 }
 
 # Renders the files from a path, taking care of the curves.
@@ -93,10 +101,14 @@ renderpathall() {
 
 # Display the render config
 showconfig() {
+    local input="${configpath}/print.scad"
+    local output="${dstpath}/print.echo"
     local config="${dstpath}/config.txt"
     createpath "${dstpath}" "output"
-    printmessage "${C_MSG}Will generates the track elements with respect to the following config:"
-    renderpath "${configpath}/print.scad" "${dstpath}" 2>&1 | sed -e '1,4d' | sed -e :a -e '$d;N;2,3ba' -e 'P;D' > "${config}"
+    printmessage "${C_MSG}The track elements would be generated with respect to the following config:"
+    scadecho "${input}" "${dstpath}" "" "" $(paramlist) > /dev/null
+    sed '1d; $d' "${output}" > "${config}"
+    rm "${output}" > /dev/null
     cat "${config}"
 }
 


### PR DESCRIPTION
Make sure the config is properly exported when rendering the scale 1/64 to 1/32 variant.
It was emptied due to the change in API brought by the last pull request.